### PR TITLE
add idiomatic OPAM file for easy pinning

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL 2.1"
+
+build: [ make "-j%{jobs}%" ]
+build-test: [ make "tests" ]
+install: [ make "install" ]
+remove: [
+  ["sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Hammer'"]
+  ["sh" "-c" "rm -f '%{bin}%/predict' '%{bin}%/htimeout'"]
+]
+depends: [ "coq" {((>= "8.8" & < "8.9~") | (= "dev"))} ]
+
+tags: [ "keyword:automation" ]
+
+authors: [
+  "Lukasz Czajka <>"
+  "Cezary Kaliszyk <>"
+]

--- a/opam
+++ b/opam
@@ -19,6 +19,7 @@ depends: [ "coq" {((>= "8.8" & < "8.9~") | (= "dev"))} ]
 tags: [ "keyword:automation" ]
 
 authors: [
-  "Lukasz Czajka <>"
-  "Cezary Kaliszyk <>"
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
 ]


### PR DESCRIPTION
Thanks for bringing a hammer to Coq, really appreciated!

Having an `opam` file in a repo is a good way to: (1) document dependencies and installation in a programmatic way, (2) provide a convenient way to install and uninstall the `HEAD` revision of a cloned repository - just do `opam pin add .` and then `opam remove <package>`. Here is what I believe is an idiomatic OPAM file.

If this looks good, I'd be happy to submit similar OPAM files for the recent GitHub releases to the [Coq OPAM repository](https://github.com/coq/opam-coq-archive) - this gives better exposure for the project and makes it easier to install - the current release there is severely outdated.

