### PR TITLE
fix compilation on Coq 8.9beta1, update opam file for 8.9

### DIFF
--- a/opam
+++ b/opam
@@ -14,9 +14,15 @@ remove: [
   ["sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Hammer'"]
   ["sh" "-c" "rm -f '%{bin}%/predict' '%{bin}%/htimeout'"]
 ]
-depends: [ "coq" {((>= "8.8" & < "8.9~") | (= "dev"))} ]
+depends: [
+  "coq" {(>= "8.8" & < "8.10~") | (= "dev")}
+]
 
-tags: [ "keyword:automation" ]
+tags: [
+  "category:Misc/Coq Extensions"
+  "keyword:automation"
+  "logpath:Hammer"
+]
 
 authors: [
   "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"

--- a/src/hammer.ml4
+++ b/src/hammer.ml4
@@ -13,10 +13,9 @@ open Hammer_errors
 open Util
 open Names
 open Term
-open Libnames
 open Globnames
-open Nametab
 open Misctypes
+open Constr
 
 open Ltac_plugin
 open Stdarg


### PR DESCRIPTION
Compilation for current master branch fails in the newly released [Coq 8.9beta1](https://github.com/coq/coq/releases/tag/V8.9%2Bbeta1). This small change fixes that and updates the OPAM file for Coq 8.9. Things appear to still work fine on 8.8.2.