### PR TITLE
Port opam file to OPAM 2, test in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,45 @@
-dist: trusty
-sudo: required
-language: generic
+language: nix
 
-services:
-  - docker
-
-env:
-  global:
-  - NJOBS="2"
-  - CONTRIB_NAME="coqhammer"
-  matrix:
-  - COQ_IMAGE="coqorg/coq:dev"
-
-install: |
-  # Prepare the COQ container
-  docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/$CONTRIB_NAME -w /home/coq/$CONTRIB_NAME ${COQ_IMAGE}
-  docker exec COQ /bin/bash --login -c "
-    # This bash script is double-quoted to interpolate Travis CI env vars:
-    echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
-    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-    set -ex  # -e = exit on failure; -x = trace for debug
-    opam list
-    "
 script:
-- echo -e "${ANSI_YELLOW}Building $CONTRIB_NAME...${ANSI_RESET}" && echo -en 'travis_fold:start:testbuild\\r'
-- |
-  docker exec COQ /bin/bash --login -c "
-    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-    set -ex
-    sudo chown -R coq:coq /home/coq/$CONTRIB_NAME
-    ( make && make install )
-    "
-- docker stop COQ  # optional
-- echo -en 'travis_fold:end:testbuild\\r'
+- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
+
+matrix:
+  include:
+
+  # Test supported versions of Coq
+  - env: COQ=https://github.com/coq/coq-on-cachix/tarball/master
+
+  # Test opam package
+  - language: minimal
+    sudo: required
+    services: docker
+    env:
+    - COQ_IMAGE=coqorg/coq:dev
+    - CONTRIB_NAME=coqhammer
+    - NJOBS=2
+    install: |
+      # Prepare the COQ container
+      docker pull ${COQ_IMAGE}
+      docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
+      docker exec COQ /bin/bash --login -c "
+        # This bash script is double-quoted to interpolate Travis CI env vars:
+        echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+        set -ex  # -e = exit on failure; -x = trace for debug
+        opam update -y
+        opam install -y -j ${NJOBS} --deps-only .
+        opam config list
+        opam repo list
+        opam list
+        "
+    script:
+    - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+    - |
+      docker exec COQ /bin/bash --login -c "
+        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+        set -ex
+        sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
+        opam install -v -y -j ${NJOBS} .
+        "
+    - docker stop COQ  # optional
+    - echo -en 'travis_fold:end:script\\r'

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+{ pkgs ? (import <nixpkgs> {}), coq-version-or-url, shell ? false }:
+
+let
+  coq-version-parts = builtins.match "([0-9]+).([0-9]+)" coq-version-or-url;
+  coqPackages =
+    if coq-version-parts == null then
+      pkgs.mkCoqPackages (import (fetchTarball coq-version-or-url) {})
+    else
+      pkgs."coqPackages_${builtins.concatStringsSep "_" coq-version-parts}";
+in
+
+with coqPackages;
+
+pkgs.stdenv.mkDerivation {
+
+  name = "coqhammer";
+
+  buildInputs = with coq.ocamlPackages; [ ocaml findlib ]
+    ++ pkgs.lib.optionals shell [ merlin ocp-indent ocp-index ];
+
+  propagatedBuildInputs = [
+    coq
+  ];
+
+  src = if shell then null else ./.;
+
+  installFlags = [ "COQBIN=$(out)/" "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
+}

--- a/opam
+++ b/opam
@@ -1,20 +1,29 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "palmskog@gmail.com"
 
 homepage: "https://github.com/lukaszcz/coqhammer"
-dev-repo: "https://github.com/lukaszcz/coqhammer.git"
+dev-repo: "git+https://github.com/lukaszcz/coqhammer.git"
 bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
 license: "LGPL-2.1-only"
 
+synopsis: "A general-purpose automated reasoning hammer tool for Coq"
+description: """
+A general-purpose automated reasoning hammer tool for Coq that combines
+learning from previous proofs with the translation of problems to the
+logics of automated systems and the reconstruction of successfully found proofs.
+"""
+
 build: [ make "-j%{jobs}%" ]
-build-test: [ make "tests" ]
 install: [ make "install" ]
 remove: [
   ["sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Hammer'"]
   ["sh" "-c" "rm -f '%{bin}%/predict' '%{bin}%/htimeout'"]
 ]
+flags: light-uninstall
 depends: [
+  "ocaml"
   "coq" {= "dev"}
+  "conf-g++" {build}
 ]
 
 tags: [


### PR DESCRIPTION
The `released` Coq OPAM archive will soon switch to OPAM 2, and the `extra-dev` archive already has. This is a port of the `opam` file to OPAM 2. I also added a CI job to test the `opam` file build separately from the regular build, based on what we are currently using for [Coq-community projects](https://github.com/coq-community).