### PR TITLE
small fix for CI job

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -7,6 +7,7 @@ htimeout: src/htimeout/htimeout.c
 	gcc -O2 -Wall src/htimeout/htimeout.c -o htimeout
 
 install-extra::
+	install -d $(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)
 	install -m 0755 predict $(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)predict
 	install -m 0755 htimeout $(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)htimeout
 

--- a/default.nix
+++ b/default.nix
@@ -18,11 +18,15 @@ pkgs.stdenv.mkDerivation {
   buildInputs = with coq.ocamlPackages; [ ocaml findlib ]
     ++ pkgs.lib.optionals shell [ merlin ocp-indent ocp-index ];
 
-  propagatedBuildInputs = [
-    coq
-  ];
+  propagatedBuildInputs = [ coq ];
 
   src = if shell then null else ./.;
 
-  installFlags = [ "COQBIN=$(out)/" "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
+  installFlags = [
+    "COQC=${coq}/bin/coqc"
+    "COQTOP=${coq}/bin/coqtop"
+    "COQMKFILE=${coq}/bin/coq_makefile"
+    "COQBIN=$(out)/bin/"
+    "COQLIB=$(out)/lib/coq/${coq.coq-version}/"
+  ];
 }


### PR DESCRIPTION
One of the CI jobs spawned after changes in #20 does not properly test installing files even when a job succeeds. Here is a somewhat convoluted fix for that, which highlights that installing the binaries `predict` and `htimeout` should probably be handled in a more general way eventually, e.g., via the dune build system.