### PR TITLE
[Makefile] Install binaries into a configurable directory

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -6,9 +6,12 @@ predict: src/predict/main.cpp src/predict/predictor.cpp src/predict/format.cpp s
 htimeout: src/htimeout/htimeout.c
 	gcc -O2 -Wall src/htimeout/htimeout.c -o htimeout
 
+BINDIR ?= $(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)
+
 install-extra::
-	install -m 0755 predict $(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)predict
-	install -m 0755 htimeout $(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)htimeout
+	install -d $(DESTDIR)$(BINDIR)
+	install -m 0755 predict $(DESTDIR)$(BINDIR)predict
+	install -m 0755 htimeout $(DESTDIR)$(BINDIR)htimeout
 
 clean::
 	rm -f predict htimeout

--- a/default.nix
+++ b/default.nix
@@ -24,5 +24,5 @@ pkgs.stdenv.mkDerivation {
 
   src = if shell then null else ./.;
 
-  installFlags = [ "COQBIN=$(out)/" "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
+  installFlags = [ "BINDIR=$(out)/bin/" "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
 }


### PR DESCRIPTION
When calling `make`, the directory in which the `predict` and `htimeout`
binaries are installed can be changed though the `BINDIR` variable.