### PR TITLE
[Makefile] Use `c++` as C++ compiler

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -4,7 +4,7 @@ predict: src/predict/main.cpp src/predict/predictor.cpp src/predict/format.cpp s
 	c++ -std=c++11 -DCOQ_MODE -O2 -Wall src/predict/main.cpp -o predict
 
 htimeout: src/htimeout/htimeout.c
-	gcc -O2 -Wall src/htimeout/htimeout.c -o htimeout
+	cc -O2 -Wall src/htimeout/htimeout.c -o htimeout
 
 install-extra::
 	install -m 0755 predict $(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)predict

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,7 +1,7 @@
 post-all:: predict htimeout
 
 predict: src/predict/main.cpp src/predict/predictor.cpp src/predict/format.cpp src/predict/knn.cpp src/predict/nbayes.cpp src/predict/rforest.cpp src/predict/tfidf.cpp src/predict/dtree.cpp
-	g++ -std=c++11 -DCOQ_MODE -O2 -Wall src/predict/main.cpp -o predict
+	c++ -std=c++11 -DCOQ_MODE -O2 -Wall src/predict/main.cpp -o predict
 
 htimeout: src/htimeout/htimeout.c
 	gcc -O2 -Wall src/htimeout/htimeout.c -o htimeout


### PR DESCRIPTION
Clang users may not have a C++ compiler named `g++`…