### PR TITLE
Independent OPAM packages for both hammer and tactics, update README and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,56 @@
-language: nix
+opam: &OPAM
+  language: minimal
+  sudo: required
+  services: docker
+  install: |
+    # Prepare the COQ container
+    docker pull ${COQ_IMAGE}
+    docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
+    docker exec COQ /bin/bash --login -c "
+      # This bash script is double-quoted to interpolate Travis CI env vars:
+      echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex  # -e = exit on failure; -x = trace for debug
+      opam update -y
+      opam pin add ${CONTRIB_NAME} . -y --no-action
+      opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
+      opam config list
+      opam repo list
+      opam list
+      "
+  script:
+  - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+  - |
+    docker exec COQ /bin/bash --login -c "
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex
+      sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
+      opam install ${CONTRIB_NAME} -v -y -j ${NJOBS}
+      "
+  - docker stop COQ  # optional
+  - echo -en 'travis_fold:end:script\\r'
 
-script:
-- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
+nix: &NIX
+  language: nix
+  script:
+  - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
 matrix:
   include:
 
-  # Test supported versions of Coq
-  - env: COQ=https://github.com/coq/coq-on-cachix/tarball/master
+  # Test supported versions of Coq via Nix
+  - env:
+    - COQ=https://github.com/coq/coq-on-cachix/tarball/master
+    <<: *NIX
 
-  # Test opam package
-  - language: minimal
-    sudo: required
-    services: docker
-    env:
+  # Test supported versions of Coq via OPAM
+  - env:
     - COQ_IMAGE=coqorg/coq:dev
-    - CONTRIB_NAME=coqhammer
+    - CONTRIB_NAME=coq-hammer
     - NJOBS=2
-    install: |
-      # Prepare the COQ container
-      docker pull ${COQ_IMAGE}
-      docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
-      docker exec COQ /bin/bash --login -c "
-        # This bash script is double-quoted to interpolate Travis CI env vars:
-        echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
-        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-        set -ex  # -e = exit on failure; -x = trace for debug
-        opam update -y
-        opam install -y -j ${NJOBS} --deps-only .
-        opam config list
-        opam repo list
-        opam list
-        "
-    script:
-    - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
-    - |
-      docker exec COQ /bin/bash --login -c "
-        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-        set -ex
-        sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
-        opam install -v -y -j ${NJOBS} .
-        "
-    - docker stop COQ  # optional
-    - echo -en 'travis_fold:end:script\\r'
+    <<: *OPAM
+  - env:
+    - COQ_IMAGE=coqorg/coq:dev
+    - CONTRIB_NAME=coq-hammer-tactics
+    - NJOBS=2
+    <<: *OPAM

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ plugin: Makefile.coq Makefile.coq.local
 tactics: Makefile.coq.tactics
 	$(MAKE) -f Makefile.coq.tactics
 
-install: install-plugin install-tactics
+install: install-plugin
 
 install-plugin: Makefile.coq Makefile.coq.local
 	$(MAKE) -f Makefile.coq install
@@ -14,7 +14,7 @@ install-plugin: Makefile.coq Makefile.coq.local
 install-tactics: Makefile.coq.tactics
 	$(MAKE) -f Makefile.coq.tactics install
 
-uninstall: uninstall-plugin uninstall-tactics
+uninstall: uninstall-plugin
 
 uninstall-plugin: Makefile.coq Makefile.coq.local
 	$(MAKE) -f Makefile.coq uninstall

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Note that some old versions of Proof General encounter problems with
 the plugin. If you use Proof General you might need the most recent
 version obtained directly from https://proofgeneral.github.io.
 
+If you are only interested in the CoqHammer's reconstruction tactics,
+they can be installed standalone (without the hammer plugin) via OPAM
+after adding the `coq-released` repository as above:
+```
+opam install coq-hammer-tactics
+```
+To instead build and install the tactics manually, use `make tactics`
+followed by `make install-tactics`.
+
 Usage
 -----
 

--- a/coq-hammer-tactics.opam
+++ b/coq-hammer-tactics.opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "git+https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "Standalone reconstruction tactics output by the hammer for Coq"
+description: """
+Standalone collection of tactics that are used by the hammer for Coq
+to reconstruct proofs found by automated theorem provers. When the hammer
+has been successfully applied to a project, only this package needs
+to be installed, eliding the full hammer plugin.
+"""
+
+build: [make "-j%{jobs}%" "tactics"]
+install: [make "install-tactics"]
+depends: [
+  "ocaml"
+  "coq" {= "dev"}
+]
+conflicts: [
+  "coq-hammer"
+]
+
+tags: [  
+  "keyword:automation"
+  "keyword:hammer"
+  "keyword:tactics"  
+  "logpath:Hammer"
+]
+
+authors: [
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
+]

--- a/coq-hammer.opam
+++ b/coq-hammer.opam
@@ -6,24 +6,22 @@ dev-repo: "git+https://github.com/lukaszcz/coqhammer.git"
 bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
 license: "LGPL-2.1-only"
 
-synopsis: "A general-purpose automated reasoning hammer tool for Coq"
+synopsis: "General-purpose automated reasoning hammer tool for Coq"
 description: """
 A general-purpose automated reasoning hammer tool for Coq that combines
 learning from previous proofs with the translation of problems to the
 logics of automated systems and the reconstruction of successfully found proofs.
 """
 
-build: [ make "-j%{jobs}%" ]
-install: [ make "install" ]
-remove: [
-  ["sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Hammer'"]
-  ["sh" "-c" "rm -f '%{bin}%/predict' '%{bin}%/htimeout'"]
-]
-flags: light-uninstall
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 depends: [
   "ocaml"
   "coq" {= "dev"}
   "conf-g++" {build}
+]
+conflicts: [
+  "coq-hammer-tactics"
 ]
 
 tags: [


### PR DESCRIPTION
Here is my proposal for updated OPAM packages for both the hammer and the tactics, and corresponding CI tasks. Note that since the plugin-related Makefile tasks subsume the tactics tasks, it's not necessary to do both.