### PR TITLE
remove parallelism from plugin opam file to rule out flakiness

### DIFF
--- a/coq-hammer.opam
+++ b/coq-hammer.opam
@@ -14,7 +14,7 @@ learning from previous proofs with the translation of problems to the
 logics of automated systems and the reconstruction of successfully found proofs.
 """
 
-build: [make "-j%{jobs}%" "plugin"]
+build: [make "plugin"]
 install: [
   [make "install-plugin"]
   [make "test-plugin"] {with-test}


### PR DESCRIPTION
Since the `coq8.9` branch is still being developed, here is the workaround for #41 for that branch as well.