### PR TITLE
update Travis CI configuration and opam packages for 8.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
-opam: &OPAM
-  language: minimal
-  sudo: required
+os: linux
+dist: bionic
+language: shell
+
+.opam: &OPAM
+  language: shell
   services: docker
   install: |
     # Prepare the COQ container
     docker pull ${COQ_IMAGE}
-    docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
+    docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${PACKAGE} -w /home/coq/${PACKAGE} ${COQ_IMAGE}
     docker exec COQ /bin/bash --login -c "
       # This bash script is double-quoted to interpolate Travis CI env vars:
       echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
@@ -14,45 +17,48 @@ opam: &OPAM
       opam update -y
       opam pin add coq-hammer-tactics . -y -n -k path
       opam pin add coq-hammer . -y -n -k path
-      opam install ${CONTRIB_NAME}.dev -y -j ${NJOBS} --deps-only
+      opam install ${PACKAGE} -y -j ${NJOBS} --deps-only
       opam config list
       opam repo list
       opam list
       "
   script:
-  - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+  - echo -e "${ANSI_YELLOW}Building ${PACKAGE}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
   - |
     docker exec COQ /bin/bash --login -c "
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex
-      sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
-      opam install ${CONTRIB_NAME}.dev -v -y -t -j ${NJOBS}
+      sudo chown -R coq:coq /home/coq/${PACKAGE}
+      opam install ${PACKAGE} -v -y -t -j ${NJOBS}
       "
   - docker stop COQ  # optional
   - echo -en 'travis_fold:end:script\\r'
 
-nix: &NIX
+.nix: &NIX
   language: nix
-  nix: 2.3.5
+  install:
+  # for cachix we need travis to be a trusted nix user
+  - echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo systemctl restart nix-daemon
   script:
   - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
-matrix:
+jobs:
   include:
 
   # Test supported versions of Coq via Nix
   - env:
-    - COQ=https://github.com/coq/coq-on-cachix/tarball/8.12
+    - COQ=8.12
     <<: *NIX
 
   # Test supported versions of Coq via OPAM
   - env:
     - COQ_IMAGE=coqorg/coq:8.12
-    - CONTRIB_NAME=coq-hammer
+    - PACKAGE=coq-hammer.8.12.dev
     - NJOBS=2
     <<: *OPAM
   - env:
     - COQ_IMAGE=coqorg/coq:8.12
-    - CONTRIB_NAME=coq-hammer-tactics
+    - PACKAGE=coq-hammer-tactics.8.12.dev
     - NJOBS=2
     <<: *OPAM

--- a/coq-hammer-tactics.opam
+++ b/coq-hammer-tactics.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "dev"
+version: "8.12.dev"
 maintainer: "palmskog@gmail.com"
 
 homepage: "https://github.com/lukaszcz/coqhammer"
@@ -15,21 +15,21 @@ has been successfully applied to a project, only this package needs
 to be installed; the hammer plugin is not required.
 """
 
-build: [make "-j%{jobs}%" "tactics"]
+build: [make "-j%{jobs}%" {ocaml:version >= "4.06"} "tactics"]
 install: [
   [make "install-tactics"]
   [make "test-tactics"] {with-test}
 ]
 depends: [
   "ocaml"
-  "coq" {= "8.12"}
+  "coq" {>= "8.12" & < "8.13~"}
 ]
 
 tags: [
   "keyword:automation"
   "keyword:hammer"
   "keyword:tactics"
-  "logpath:Hammer"
+  "logpath:Hammer.Tactics"
 ]
 
 authors: [

--- a/coq-hammer.opam
+++ b/coq-hammer.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "dev"
+version: "8.12.dev"
 maintainer: "palmskog@gmail.com"
 
 homepage: "https://github.com/lukaszcz/coqhammer"
@@ -14,15 +14,15 @@ learning from previous proofs with the translation of problems to the
 logics of automated systems and the reconstruction of successfully found proofs.
 """
 
-build: [make "plugin"]
+build: [make "-j%{jobs}%" {ocaml:version >= "4.06"} "plugin"]
 install: [
   [make "install-plugin"]
   [make "test-plugin"] {with-test}
 ]
 depends: [
   "ocaml"
-  "coq" {= "8.12"}
-  "conf-g++" {build}
+  "coq" {>= "8.12" & < "8.13~"}
+  ("conf-g++" {build} | "conf-clang" {build})
   "coq-hammer-tactics" {= version}
 ]
 
@@ -30,7 +30,7 @@ tags: [
   "category:Miscellaneous/Coq Extensions"
   "keyword:automation"
   "keyword:hammer"
-  "logpath:Hammer"
+  "logpath:Hammer.Plugin"
 ]
 
 authors: [


### PR DESCRIPTION
This uses best practices from coq-community on using opam, Nix and Travis.