### PR TITLE
update Travis CI configuration and opam packages for 8.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
-opam: &OPAM
-  language: minimal
-  sudo: required
+os: linux
+dist: bionic
+language: shell
+
+.opam: &OPAM
+  language: shell
   services: docker
   install: |
     # Prepare the COQ container
@@ -31,13 +34,16 @@ opam: &OPAM
   - docker stop COQ  # optional
   - echo -en 'travis_fold:end:script\\r'
 
-nix: &NIX
+.nix: &NIX
   language: nix
-  nix: 2.3.5
+  install:
+  # for cachix we need travis to be a trusted nix user
+  - echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo systemctl restart nix-daemon
   script:
   - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
-matrix:
+jobs:
   include:
 
   # Test supported versions of Coq via Nix

--- a/coq-hammer-tactics.opam
+++ b/coq-hammer-tactics.opam
@@ -29,7 +29,7 @@ tags: [
   "keyword:automation"
   "keyword:hammer"
   "keyword:tactics"
-  "logpath:Hammer"
+  "logpath:Hammer.Tactics"
 ]
 
 authors: [

--- a/coq-hammer.opam
+++ b/coq-hammer.opam
@@ -30,7 +30,7 @@ tags: [
   "category:Miscellaneous/Coq Extensions"
   "keyword:automation"
   "keyword:hammer"
-  "logpath:Hammer"
+  "logpath:Hammer.Plugin"
 ]
 
 authors: [


### PR DESCRIPTION
Last opam and Travis CI refresh, since I believe the `coq8.9` branch is no longer receiving updates.

Fixes #41.

