### PR TITLE
standard Dune tactics build should not include Mathcomp.v

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ setup.data
 setup.log
 /src/hammer.ml
 .merlin
+*.install

--- a/theories/Tactics/dune
+++ b/theories/Tactics/dune
@@ -2,4 +2,5 @@
  (name Hammer.Tactics)
  (package coq-hammer-tactics)
  (synopsis "CoqHammer Coq tactics")
+ (modules :standard \ Mathcomp)
  (libraries coq-hammer-tactics.lib coq-hammer-tactics.tactics))


### PR DESCRIPTION
I noticed that the default Dune build of `coq-hammer-tactics` included `Mathcomp.v`, which makes the whole Dune package depend on `coq-mathcomp-ssreflect`. This small change avoids including `Mathcomp.v` in the build.

More generally, the lemmas and hints in `Mathcomp.v` look like they are superceded by the `zify` tactic and instances for `zify` of MathComp numbers in [mczify](https://github.com/pi8027/mczify).

For example, mczify can be used to solve MathComp arithmetic goals like the following:
```coq
From Coq Require Import Zify.
From Hammer Require Import Tactics.
From mathcomp Require Import all_ssreflect.
From mathcomp Require Import zify.

Lemma constr_thirds n : (n %/ 3).+1 + n <= 2 * (2 * n %/ 3).+1.
Proof.
zify. (* turns the goal into a problem on Z integers *)
sauto. (* lia alone suffices *)
Qed.
```
This is not to say that providing MathComp rewriting hints for `sauto` and `Reflect` isn't useful in general (e.g., for `orP` or `andP`), just that the stuff currently in `Mathcomp.v` is not needed when `zify`/mczify is available.