### PR TITLE
Adjust Dune build flags and add tests via Dune for 8.12

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.5)
 (using coq 0.2)
-(name hammer)
+(name coqhammer)

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -2,7 +2,7 @@
  (name hammer_lib)
  (public_name coq-hammer-tactics.lib)
  (synopsis "CoqHammer library")
- (flags :standard -rectypes -warn-error -3-8-9-14-27-34)
+ (flags :standard -rectypes -w -3-9-27)
  (libraries coq.plugins.ltac)
  (wrapped false))
 

--- a/src/plugin/dune
+++ b/src/plugin/dune
@@ -2,7 +2,7 @@
  (name hammer_plugin)
  (public_name coq-hammer.plugin)
  (synopsis "CoqHammer plugin")
- (flags :standard -rectypes -warn-error -3-8-9-14-27-34-A)
+ (flags :standard -rectypes -w -3-9-27)
  (libraries coq.plugins.ltac coq.vernac coq-hammer-tactics.lib coq-hammer-tactics.tactics)
  (wrapped false))
 

--- a/src/tactics/dune
+++ b/src/tactics/dune
@@ -2,7 +2,7 @@
  (name hammer_tactics)
  (public_name coq-hammer-tactics.tactics)
  (synopsis "CoqHammer tactics")
- (flags :standard -rectypes -warn-error -3-8-9-14-27-34)
+ (flags :standard -rectypes -w -3-27)
  (libraries coq.plugins.ltac coq-hammer-tactics.lib)
  (wrapped false))
 

--- a/tests/dune
+++ b/tests/dune
@@ -1,0 +1,9 @@
+(rule
+ (alias runtest)
+ (deps (:vfile plugin_test.v))
+ (action (run coqc %{vfile})))
+
+(rule
+ (alias runtest)
+ (deps (:vfile tactics_test.v))
+ (action (run coqc %{vfile})))


### PR DESCRIPTION
Here are some adjustments to Dune builds to follow best practices. I also added tests corresponding to `test-plugin` and `test-tactics`. Regular Make builds are untouched.

Note that Dune does not allow running tests separately unless the files are located in different directories (unlike `tests/tactics_test.v` and `tests/plugin_test.v`). So maybe the `tests` directory could be partitioned into `tests/tactics` and `tests/plugin`? I can add this to the PR if such a change would be welcome.