### PR TITLE
'use' option accepts lemmas with implicit arguments.

### DIFF
--- a/src/lib/hhutils.ml
+++ b/src/lib/hhutils.ml
@@ -3,9 +3,7 @@ open Names
 open Ltac_plugin
 
 let intern_constr env evd cexpr =
-  let (t, uctx) = Constrintern.interp_constr env evd cexpr in
-  let sigma = Evd.from_ctx uctx in
-  Typing.solve_evars env sigma t
+  Constrintern.interp_constr_evars env evd cexpr
 
 let tacinterp tac =
   Tacinterp.tactic_of_value (Tacinterp.default_ist ()) tac

--- a/src/tactics/g_hammer_tactics.mlg
+++ b/src/tactics/g_hammer_tactics.mlg
@@ -5,7 +5,7 @@ open Ltac_plugin
 open Stdarg
 open Tacarg
 open Pcoq.Prim
-open Pcoq.Constr
+open Pltac
 open Hammer_lib
 open Hammer_errors
 open Sauto
@@ -24,12 +24,12 @@ ARGUMENT EXTEND sauto_bopt
 END
 
 ARGUMENT EXTEND sauto_opts
-| [ "using" ne_constr_list_sep(l, ",") sauto_opts(sopts) ] -> { SOUse l :: sopts }
+| [ "using" ne_uconstr_list_sep(l, ",") sauto_opts(sopts) ] -> { SOUse l :: sopts }
 | [ "unfolding" ne_reference_list_sep(l, ",") sauto_opts(sopts) ] -> { SOUnfold l :: sopts }
 | [ "inverting" ne_reference_list_sep(l, ",") sauto_opts(sopts) ] -> { SOInv l :: sopts }
 | [ "with" ne_preident_list_sep(l, ",") sauto_opts(sopts) ] -> { SOBases l :: sopts }
-| [ "use:" ne_constr_list_sep(l, ",") sauto_opts(sopts) ] -> { SOUse l :: sopts }
-| [ "gen:" ne_constr_list_sep(l, ",") sauto_opts(sopts) ] -> { SOGen l :: sopts }
+| [ "use:" ne_uconstr_list_sep(l, ",") sauto_opts(sopts) ] -> { SOUse l :: sopts }
+| [ "gen:" ne_uconstr_list_sep(l, ",") sauto_opts(sopts) ] -> { SOGen l :: sopts }
 | [ "unfold:" "*" sauto_opts(sopts) ] -> { SOUnfoldAll :: sopts }
 | [ "unfold:" "-" sauto_opts(sopts) ] -> { SOUnfoldNone :: sopts }
 | [ "unfold:" ne_reference_list_sep(l, ",") sauto_opts(sopts) ] -> { SOUnfold l :: sopts }
@@ -310,8 +310,8 @@ TACTIC EXTEND Hammer_sauto_actions
 END
 
 TACTIC EXTEND Hammer_use
-| [ "use" ne_constr_list_sep(l, ",") ] -> {
-  try_tactic (fun () -> use_lemmas l)
+| [ "use" ne_uconstr_list_sep(l, ",") ] -> {
+  try_tactic (fun () -> use_lemmas ist l)
 }
 END
 

--- a/src/tactics/tacopts.ml
+++ b/src/tactics/tacopts.ml
@@ -228,7 +228,7 @@ let interp_use use ret opts lst env sigma =
     else
       opts
   in
-  use lems <*> ret opts
+  Tacticals.New.tclWITHHOLES true (use lems) sigma <*> ret opts
 
 let mk_final tac =
   let sfinal =

--- a/src/tactics/tactics_main.ml
+++ b/src/tactics/tactics_main.ml
@@ -18,7 +18,7 @@ let try_usolve (opts : s_opts) (lst : sopt_t list) (ret : s_opts -> unit Proofvi
         end
   end
 
-let with_delayed_uconstrs ist cs tac =
+let with_delayed_uconstr ist c tac =
   let flags = {
     Pretyping.use_typeclasses = Pretyping.UseTC;
     solve_unification_constraints = true;
@@ -27,12 +27,13 @@ let with_delayed_uconstrs ist cs tac =
     program_mode = false;
     polymorphic = false;
   } in
-  let cs = List.map (Tacinterp.type_uconstr ~flags ist) cs in
-  Tacticals.New.tclMAPDELAYEDWITHHOLES true cs tac
+  let c = Tacinterp.type_uconstr ~flags ist c in
+  Tacticals.New.tclDELAYEDWITHHOLES true c tac
 
 let use_lemmas ist lst =
   let use_tac t =
     Tactics.generalize [t] <*>
       Utils.ltac_eval "Tactics.use_tac" []
   in
-  with_delayed_uconstrs ist lst use_tac
+  List.fold_left (fun tac t -> tac <*> with_delayed_uconstr ist t use_tac)
+    Tacticals.New.tclIDTAC lst

--- a/src/tactics/tactics_main.ml
+++ b/src/tactics/tactics_main.ml
@@ -18,8 +18,21 @@ let try_usolve (opts : s_opts) (lst : sopt_t list) (ret : s_opts -> unit Proofvi
         end
   end
 
-let use_lemmas lst =
+let with_delayed_uconstrs ist cs tac =
+  let flags = {
+    Pretyping.use_typeclasses = Pretyping.UseTC;
+    solve_unification_constraints = true;
+    fail_evar = false;
+    expand_evars = true;
+    program_mode = false;
+    polymorphic = false;
+  } in
+  let cs = List.map (Tacinterp.type_uconstr ~flags ist) cs in
+  Tacticals.New.tclMAPDELAYEDWITHHOLES true cs tac
+
+let use_lemmas ist lst =
   let use_tac t =
-    Utils.ltac_eval "Tactics.use_tac" [Tacinterp.Value.of_constr t]
+    Tactics.generalize [t] <*>
+      Utils.ltac_eval "Tactics.use_tac" []
   in
-  List.fold_left (fun tac t -> tac <*> use_tac t) Tacticals.New.tclIDTAC lst
+  with_delayed_uconstrs ist lst use_tac

--- a/tests/tactics/tactics_test.v
+++ b/tests/tactics/tactics_test.v
@@ -43,6 +43,37 @@ Proof.
   sauto.
 Qed.
 
+Lemma lem_implicit_arg {A} : forall l : list A, List.map id l = l.
+Proof.
+  sauto use: List.map_id.
+Qed.
+
+Lemma test_implicit_arg1 {A} : forall l : list A, List.map id l = l.
+Proof.
+  sauto use: lem_implicit_arg.
+Qed.
+
+Class Mere A := {
+  mere : forall x y : A, x = y
+}.
+
+Lemma lem_implicit_arg2 {A} `{Mere A} {B} (f g : B -> A) :
+  forall l : list B, List.map f l = List.map g l.
+Proof.
+  induction l; sauto.
+Qed.
+
+Instance mere_unit : Mere unit.
+Proof.
+  sauto.
+Qed.
+
+Lemma test_implicit_arg2 {B} :
+  forall (l : list B) (f g : B -> unit), List.map f l = List.map g l.
+Proof.
+  sauto use: lem_implicit_arg2.
+Qed.
+
 Require Import Arith.
 
 Lemma lem_test_csplit : forall n, if n =? n then True else False.

--- a/theories/Tactics/Tactics.v
+++ b/theories/Tactics/Tactics.v
@@ -1044,8 +1044,8 @@ Tactic Notation "generalize" "proofs" := generalize_proofs_in_goal.
 Tactic Notation "generalize" "proofs" "in" ident(H) := generalize_proofs_in_hyp H.
 Tactic Notation "generalize" "proofs" "in" "*" := generalize_proofs.
 
-Ltac use_tac t :=
-  let H := fresh "H" in generalize t; intro H; try move H at top; try simp_hyp H.
+Ltac use_tac :=
+  let H := fresh "H" in intro H; try move H at top; try simp_hyp H.
 
 Ltac congr_tac := congruence 400.
 Ltac lia_tac := lia.


### PR DESCRIPTION
A few things worth noting:
1. Due to my limited experience in Coq plugin development, I am not sure if this patch introduces regression. I did run `make tests` to make sure it at least passes all the tests, and it works fine in my own development.
2. I removed the `Typing.solve_evars` call in `hhutils.ml` because it may not be needed now. But I am not entirely sure.
3. I moved the `generalize` call in `use_tac` defined in `Tactics.v` to `use_lems` in `tactics_main.ml`, because I don't know how to pass an uconstr to `ltac_eval`. The name `use_tac` may be a bit misleading now.
4. I added a few test cases for this, though they are rather contrived. I am not able to figure out a minimal test case that fails with `sauto use: @lem` but works with `sauto use: lem` (that happens in my own development which involves a lot more). However, I observed a 10x speedup without `@` in the test case `test_implicit_arg2` in my environment.