### PR TITLE
Don't use Mltop.add_known_plugin

### DIFF
--- a/src/plugin/g_hammer.mlg
+++ b/src/plugin/g_hammer.mlg
@@ -8,10 +8,6 @@ open Tacarg
 
 let hammer_version_string = "CoqHammer (dev) for Coq master"
 
-let () = Mltop.add_known_plugin (fun () ->
-  Flags.if_verbose Feedback.msg_info Pp.(str hammer_version_string))
-  "coq-hammer.plugin"
-
 open Hammer_main
 
 }


### PR DESCRIPTION

It will probably be removed eg in
https://github.com/coq/coq/pull/17069

This is used only to automatically print the version when loading the
plugin, there is already the `Hammer_version` command so IMO no point
writing a replacement.
