### PR TITLE
Adapt to Coq PR #17987 which adds sigma to the API of search functions

### DIFF
--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -206,25 +206,26 @@ let string_of_goal gl =
   string_of (EConstr.to_constr (Proofview.Goal.sigma gl) (Proofview.Goal.concl gl))
 
 let my_search env =
-  let save_in_list refl glob_ref env c = refl := glob_ref :: !refl in
+  let save_in_list refl glob_ref env sigma c = refl := glob_ref :: !refl in
   let ans = ref [] in
   let filter_modules glob_ref =
     Opt.FilterSet.for_all (fun m -> not (Utils.match_globref m glob_ref))
       (Opt.HammerFilterTable.v ())
   in
-  let filter glob_ref kind env typ =
+  let filter glob_ref kind env sigma typ =
     (if !Opt.search_blacklist then
-       Search.blacklist_filter glob_ref kind env (Evd.from_env env) typ
+       Search.blacklist_filter glob_ref kind env sigma typ
      else
        true)
     &&
     filter_modules glob_ref
   in
-  let iter glob_ref kind env typ =
-    if filter glob_ref kind env typ then save_in_list ans glob_ref env typ
+  let iter glob_ref kind env sigma typ =
+    if filter glob_ref kind env sigma typ then save_in_list ans glob_ref env sigma typ
   in
   let env = Global.env () in
-  let () = Search.generic_search env iter in
+  let sigma = Evd.from_env env in
+  let () = Search.generic_search env sigma iter in
   List.filter
     begin fun glob_ref ->
       try


### PR DESCRIPTION
The Coq PR is to fix #17963: sigma has to be passed to search functions.

It has to be merged synchronously with coq/coq#17987.