### PR TITLE
simplify opam files in master

### DIFF
--- a/coq-hammer-tactics.opam
+++ b/coq-hammer-tactics.opam
@@ -15,13 +15,13 @@ has been successfully applied to a project, only this package needs
 to be installed; the hammer plugin is not required.
 """
 
-build: [make "-j%{jobs}%" {ocaml:version >= "4.08"} "tactics"]
+build: [make "-j%{jobs}%" "tactics"]
 install: [
   [make "install-tactics"]
   [make "test-tactics"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.09.0"}
   "coq" {= "dev"}
 ]
 

--- a/coq-hammer.opam
+++ b/coq-hammer.opam
@@ -14,13 +14,13 @@ learning from previous proofs with the translation of problems to the
 logics of automated systems and the reconstruction of successfully found proofs.
 """
 
-build: [make "-j%{jobs}%" {ocaml:version >= "4.08"} "plugin"]
+build: [make "-j%{jobs}%" "plugin"]
 install: [
   [make "install-plugin"]
   [make "test-plugin"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.09.0"}
   "coq" {= "dev"}
   ("conf-g++" {build} | "conf-clang" {build})
   "coq-hammer-tactics" {= version}


### PR DESCRIPTION
The minimum version of OCaml for current Coq `master` is 4.09.0. Hence, we can simplify the opam files that had a workaround for a bug affecting earlier OCaml.