### PR TITLE
Update coq-hammer-tactics.opam

### DIFF
--- a/coq-hammer-tactics.opam
+++ b/coq-hammer-tactics.opam
@@ -22,7 +22,7 @@ install: [
 ]
 depends: [
   "ocaml" {>= "4.09.0"}
-  "coq" {= "dev"}
+  "rocq-stdlib" {= "dev"}
 ]
 
 tags: [

--- a/coq-hammer.opam
+++ b/coq-hammer.opam
@@ -21,7 +21,7 @@ install: [
 ]
 depends: [
   "ocaml" {>= "4.09.0"}
-  "coq" {= "dev"}
+  "rocq-stdlib" {= "dev"}
   ("conf-g++" {build} | "conf-clang" {build})
   "coq-hammer-tactics" {= version}
 ]


### PR DESCRIPTION
"coq" {= "dev"} includes the coq ide server. I don't think Coqhammer needs the IDE server, does it?