### PR TITLE
hammer with given lemmas

### DIFF
--- a/src/plugin/features.ml
+++ b/src/plugin/features.ml
@@ -149,8 +149,6 @@ let get_deps_cached (def : hhdef) : string list =
     Hashtbl.add deps_cache name deps;
     deps
 
-
-
 let is_nontrivial (def : hhdef) : bool =
   let name = get_hhdef_name def in
   name <> "" && not (Hhlib.string_begins_with name "Coq.Init.Logic.") &&
@@ -196,13 +194,15 @@ let extract (hyps : hhdef list) (defs : hhdef list) (goal : hhdef) : string =
   close_out oc;
   fname
 
-let extract_given_lemmas (hyps : hhdef list) (defs : hhdef list) (lems : hhdef list) (goal : hhdef) (atpname : string) =
-  Msg.info "Extracting definitions...";
+let choose_given_lemmas (hyps : hhdef list) (defs : hhdef list) (lems : hhdef list) (goal : hhdef) (atpname : string) =
+  Msg.info "Choosing definitions...";
   let defss = List.filter is_nontrivial defs in
+  if lems = [] then
+     raise (HammerError ("No lemmas given for choice."));
   if !Opt.debug_mode then
     Msg.info ("After filtering: " ^ string_of_int (List.length defss) ^ " Coq objects.");
   let names = Hhlib.strset_from_lst (List.map get_hhdef_name defss) in
-  let write_def def =
+  let choose_def def =
     let name = get_hhdef_name def in
     let pre_deps = get_deps_cached def in
     let deps = List.filter (fun a -> Hhlib.StringSet.mem a names) pre_deps in
@@ -210,32 +210,11 @@ let extract_given_lemmas (hyps : hhdef list) (defs : hhdef list) (lems : hhdef l
   in
   let goal_deps = get_deps_cached goal in
   let goal_deps = List.filter (fun a -> Hhlib.StringSet.mem a names) goal_deps in
-  let ths_deps = List.sort_uniq Stdlib.compare (goal_deps @ (List.concat (List.map write_def lems))) in 
-
-  let oname = Filename.temp_file ("coqhammer_out" ^ atpname) "" in
-  let info = "Write " ^ atpname ^ " to file " ^ oname ^ " with arguments: " ^ String.concat " " ths_deps in
-  let ocname = open_out oname in
-  output_string ocname (String.concat " " ths_deps);
-  close_out ocname;
-  
+  let ths_deps = List.sort_uniq Stdlib.compare (goal_deps @ (List.concat (List.map choose_def lems))) in
   if !Opt.debug_mode || !Opt.gs_mode = 0 then
     Msg.info ("Running dependency extraction...");
-  if !Opt.debug_mode then
-    Msg.info info;
-  let ic = open_in oname in
-  try
-    let predicts =
-      Hhlib.strset_from_lst
-        (Str.split (Str.regexp " ")
-           (try input_line ic with End_of_file ->
-             close_in ic; Sys.remove oname;
-             raise (HammerError "Predictor did not return advice.")))
-    in
-    close_in ic; Sys.remove oname;
-    List.filter (fun def -> Hhlib.StringSet.mem (get_hhdef_name def) predicts) defs
-  with e ->
-    close_in ic; Sys.remove oname;
-    raise e
+  let objs = Hhlib.strset_from_lst ths_deps in
+  List.filter (fun def -> Hhlib.StringSet.mem (get_hhdef_name def) objs) defs
 
 let run_predict fname defs pred_num pred_method =
   let oname = Filename.temp_file ("coqhammer_out" ^ pred_method ^ string_of_int pred_num) "" in

--- a/src/plugin/features.ml
+++ b/src/plugin/features.ml
@@ -149,6 +149,8 @@ let get_deps_cached (def : hhdef) : string list =
     Hashtbl.add deps_cache name deps;
     deps
 
+
+
 let is_nontrivial (def : hhdef) : bool =
   let name = get_hhdef_name def in
   name <> "" && not (Hhlib.string_begins_with name "Coq.Init.Logic.") &&
@@ -193,6 +195,47 @@ let extract (hyps : hhdef list) (defs : hhdef list) (goal : hhdef) : string =
   output_string oc "\"\n";
   close_out oc;
   fname
+
+let extract_given_lemmas (hyps : hhdef list) (defs : hhdef list) (lems : hhdef list) (goal : hhdef) (atpname : string) =
+  Msg.info "Extracting definitions...";
+  let defss = List.filter is_nontrivial defs in
+  if !Opt.debug_mode then
+    Msg.info ("After filtering: " ^ string_of_int (List.length defss) ^ " Coq objects.");
+  let names = Hhlib.strset_from_lst (List.map get_hhdef_name defss) in
+  let write_def def =
+    let name = get_hhdef_name def in
+    let pre_deps = get_deps_cached def in
+    let deps = List.filter (fun a -> Hhlib.StringSet.mem a names) pre_deps in
+    name::deps
+  in
+  let goal_deps = get_deps_cached goal in
+  let goal_deps = List.filter (fun a -> Hhlib.StringSet.mem a names) goal_deps in
+  let ths_deps = List.sort_uniq Stdlib.compare (goal_deps @ (List.concat (List.map write_def lems))) in 
+
+  let oname = Filename.temp_file ("coqhammer_out" ^ atpname) "" in
+  let info = "Write " ^ atpname ^ " to file " ^ oname ^ " with arguments: " ^ String.concat " " ths_deps in
+  let ocname = open_out oname in
+  output_string ocname (String.concat " " ths_deps);
+  close_out ocname;
+  
+  if !Opt.debug_mode || !Opt.gs_mode = 0 then
+    Msg.info ("Running dependency extraction...");
+  if !Opt.debug_mode then
+    Msg.info info;
+  let ic = open_in oname in
+  try
+    let predicts =
+      Hhlib.strset_from_lst
+        (Str.split (Str.regexp " ")
+           (try input_line ic with End_of_file ->
+             close_in ic; Sys.remove oname;
+             raise (HammerError "Predictor did not return advice.")))
+    in
+    close_in ic; Sys.remove oname;
+    List.filter (fun def -> Hhlib.StringSet.mem (get_hhdef_name def) predicts) defs
+  with e ->
+    close_in ic; Sys.remove oname;
+    raise e
 
 let run_predict fname defs pred_num pred_method =
   let oname = Filename.temp_file ("coqhammer_out" ^ pred_method ^ string_of_int pred_num) "" in

--- a/src/plugin/features.ml
+++ b/src/plugin/features.ml
@@ -214,26 +214,24 @@ let extract (hyps : hhdef list) (defs : hhdef list) (goal : hhdef) : string =
   close_out oc;
   fname
 
-let choose_given_lemmas (hyps : hhdef list) (defs : hhdef list) (lems : hhdef list) (goal : hhdef) (atpname : string) =
+let choose_given_lemmas (hyps : hhdef list) (defs : hhdef list) (lems : hhdef list) (goal : hhdef) : hhdef list =
   Msg.info "Choosing definitions...";
-  let defss = List.filter is_nontrivial defs in
-  if lems = [] then
-     raise (HammerError ("No lemmas given for choice."));
+  let ndefs = List.filter is_nontrivial defs in
   if !Opt.debug_mode then
-    Msg.info ("After filtering: " ^ string_of_int (List.length defss) ^ " Coq objects.");
-  let names = Hhlib.strset_from_lst (List.map get_hhdef_name defss) in
+    Msg.info ("After filtering: " ^ string_of_int (List.length ndefs) ^ " Coq objects.");
+  let names = Hhlib.strset_from_lst (List.map get_hhdef_name ndefs) in
+  let filter_deps deps = List.filter (fun a -> Hhlib.StringSet.mem a names) deps in
   let choose_def def =
-    let name = get_hhdef_name def in
-    let pre_deps = get_deps_cached def in
-    let deps = List.filter (fun a -> Hhlib.StringSet.mem a names) pre_deps in
-    name::deps
+    get_hhdef_name def :: filter_deps (get_deps_cached def)
   in
-  let goal_deps = get_deps_cached goal in
-  let goal_deps = List.filter (fun a -> Hhlib.StringSet.mem a names) goal_deps in
-  let ths_deps = List.sort_uniq Stdlib.compare (goal_deps @ (List.concat (List.map choose_def lems))) in
-  if !Opt.debug_mode || !Opt.gs_mode = 0 then
-    Msg.info ("Running dependency extraction...");
-  let objs = Hhlib.strset_from_lst ths_deps in
+  (* The goal and the hypotheses are local to the current proof, so
+     their dependencies must not be cached under their names. *)
+  let goal_deps = filter_deps (get_deps goal) in
+  let hyps_deps = List.concat (List.map (fun h -> filter_deps (get_deps h)) hyps) in
+  let objs =
+    Hhlib.strset_from_lst
+      (goal_deps @ hyps_deps @ List.concat (List.map choose_def lems))
+  in
   List.filter (fun def -> Hhlib.StringSet.mem (get_hhdef_name def) objs) defs
 
 let run_predict fname defs pred_num pred_method =

--- a/src/plugin/features.ml
+++ b/src/plugin/features.ml
@@ -151,23 +151,32 @@ let cleanup () =
   Hashtbl.reset features_cache;
   Hashtbl.reset deps_cache
 
+(* Variables must not be cached under their names: the same name may
+   denote a different variable in another section or proof. *)
+
 let get_def_features_cached (def : hhdef) : string list =
-  let name = get_hhdef_name def in
-  try
-    Hashtbl.find features_cache name
-  with Not_found ->
-    let fea = get_def_features def in
-    Hashtbl.add features_cache name fea;
-    fea
+  if hhdef_is_var def then
+    get_def_features def
+  else
+    let name = get_hhdef_name def in
+    try
+      Hashtbl.find features_cache name
+    with Not_found ->
+      let fea = get_def_features def in
+      Hashtbl.add features_cache name fea;
+      fea
 
 let get_deps_cached (def : hhdef) : string list =
-  let name = get_hhdef_name def in
-  try
-    Hashtbl.find deps_cache name
-  with Not_found ->
-    let deps = get_deps def in
-    Hashtbl.add deps_cache name deps;
-    deps
+  if hhdef_is_var def then
+    get_deps def
+  else
+    let name = get_hhdef_name def in
+    try
+      Hashtbl.find deps_cache name
+    with Not_found ->
+      let deps = get_deps def in
+      Hashtbl.add deps_cache name deps;
+      deps
 
 let is_nontrivial (def : hhdef) : bool =
   let name = get_hhdef_name def in

--- a/src/plugin/features.mli
+++ b/src/plugin/features.mli
@@ -10,8 +10,8 @@ val get_goal_features : hhdef list (* hyps *) -> hhdef (* goal *) -> string list
 val extract : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef (* goal *) ->
   string (* (temporary) file name *)
 
-val extract_given_lemmas : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef list (* argus *) -> hhdef (* goal *) -> string (*  *) -> 
-  hhdef list (* (temporary) file name *)
+val extract_given_lemmas : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef list (* lemmas *) -> hhdef (* goal *) -> string (* ATP name *) -> 
+  hhdef list (* used objects *)
 
 val run_predict : string (* file name (from `extract`) *) -> hhdef list (* defs *) ->
   int (* pred_num *) -> string (* pred_method *) ->

--- a/src/plugin/features.mli
+++ b/src/plugin/features.mli
@@ -10,7 +10,7 @@ val get_goal_features : hhdef list (* hyps *) -> hhdef (* goal *) -> string list
 val extract : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef (* goal *) ->
   string (* (temporary) file name *)
 
-val extract_given_lemmas : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef list (* lemmas *) -> hhdef (* goal *) -> string (* ATP name *) -> 
+val choose_given_lemmas : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef list (* lemmas *) -> hhdef (* goal *) -> string (* ATP name *) -> 
   hhdef list (* used objects *)
 
 val run_predict : string (* file name (from `extract`) *) -> hhdef list (* defs *) ->

--- a/src/plugin/features.mli
+++ b/src/plugin/features.mli
@@ -10,6 +10,9 @@ val get_goal_features : hhdef list (* hyps *) -> hhdef (* goal *) -> string list
 val extract : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef (* goal *) ->
   string (* (temporary) file name *)
 
+val extract_given_lemmas : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef list (* argus *) -> hhdef (* goal *) -> string (*  *) -> 
+  hhdef list (* (temporary) file name *)
+
 val run_predict : string (* file name (from `extract`) *) -> hhdef list (* defs *) ->
   int (* pred_num *) -> string (* pred_method *) ->
   hhdef list (* predictions *)

--- a/src/plugin/features.mli
+++ b/src/plugin/features.mli
@@ -10,8 +10,13 @@ val get_goal_features : hhdef list (* hyps *) -> hhdef (* goal *) -> string list
 val extract : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef (* goal *) ->
   string (* (temporary) file name *)
 
-val choose_given_lemmas : hhdef list (* hyps *) -> hhdef list (* defs *) -> hhdef list (* lemmas *) -> hhdef (* goal *) -> string (* ATP name *) -> 
-  hhdef list (* used objects *)
+(* `choose_given_lemmas` selects the premises for the ATPs based on
+   the given lemmas: the lemmas themselves plus the definitions
+   directly referenced by the goal, the hypotheses or the lemmas.
+   The given lemmas must occur in the defs list. *)
+val choose_given_lemmas : hhdef list (* hyps *) -> hhdef list (* defs *) ->
+  hhdef list (* lemmas *) -> hhdef (* goal *) ->
+  hhdef list (* premises *)
 
 val run_predict : string (* file name (from `extract`) *) -> hhdef list (* defs *) ->
   int (* pred_num *) -> string (* pred_method *) ->

--- a/src/plugin/g_hammer.mlg
+++ b/src/plugin/g_hammer.mlg
@@ -13,10 +13,9 @@ open Hammer_main
 }
 
 TACTIC EXTEND Hammer_tac
-| [ "hammer" ] -> { hammer_tac [] }
-| [ "hammer" "[" constr_list(l) "]" ] -> { hammer_tac l }
+| [ "hammer" ] -> { hammer_tac Prediction }
+| [ "hammer" "[" constr_list(l) "]" ] -> { hammer_tac (Choice l) }
 END
-
 
 TACTIC EXTEND Predict_tac_1
 | [ "predict" integer(n) ] -> { predict_tac n !Opt.predict_method }

--- a/src/plugin/g_hammer.mlg
+++ b/src/plugin/g_hammer.mlg
@@ -13,8 +13,10 @@ open Hammer_main
 }
 
 TACTIC EXTEND Hammer_tac
-| [ "hammer" ] -> { hammer_tac () }
+| [ "hammer" ] -> { hammer_tac [] }
+| [ "hammer" "[" constr_list(l) "]" ] -> { hammer_tac l }
 END
+
 
 TACTIC EXTEND Predict_tac_1
 | [ "predict" integer(n) ] -> { predict_tac n !Opt.predict_method }

--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -260,7 +260,9 @@ let get_argus env sigma l : Hh_term.hhdef list =
   let argu_refs = 
     List.map (fun c -> 
       try let r, _ = Termops.global_of_constr sigma c in r
-      with _ -> raise (HammerError ("Argument " ^ (Utils.constr_to_string sigma c) ^ " not found in environment."))
+      with
+      | Sys.Break -> raise Sys.Break
+      | _ -> raise (HammerError ("Argument " ^ (Utils.constr_to_string sigma c) ^ " not found in environment."))
       ) l in
   List.map snd (unique_hhdefs
                   (List.map (hhdef_of_global env sigma) argu_refs))

--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -15,6 +15,9 @@ open Ltac_plugin
 module Utils = Hhutils
 
 (***************************************************************************************)
+type hammer_mode = 
+  | Prediction 
+  | Choice of EConstr.t list
 
 let mk_id x = Hh_term.Id x
 let mk_app x y = Hh_term.Comb(x, y)
@@ -733,7 +736,7 @@ let do_predict hyps deps goal =
     let deps1 = Features.predict hyps deps goal in
     Provers.predict deps1 hyps deps goal
 
-let do_extraction hyps deps goal lems =
+let do_choice hyps deps goal lems =
   if !Opt.gs_mode > 0 then
     (* The last argument (0) is not used as a clustering parameter.
        It's only a placeholder to reuse the function structure. *)
@@ -755,7 +758,7 @@ let do_extraction hyps deps goal lems =
           pref := true;
           Opt.parallel_mode := false;
           try
-            let deps1 = Features.extract_given_lemmas hyps deps lems goal pred_method in
+            let deps1 = Features.choose_given_lemmas hyps deps lems goal pred_method in
             (* All hypotheses are always passed to the ATPs (only deps
                are subject to premise selection) *)
             let info = Provers.predict deps1 hyps deps goal in
@@ -802,7 +805,7 @@ let do_extraction hyps deps goal lems =
          info
        end
   else (* Opts.gs_mode = 0 *)
-    let deps1 = Features.extract_given_lemmas hyps deps lems goal !Opt.predict_method in
+    let deps1 = Features.choose_given_lemmas hyps deps lems goal !Opt.predict_method in
     Provers.predict deps1 hyps deps goal
 
 let try_sauto () =
@@ -822,19 +825,20 @@ let try_sauto () =
 
 let provers_detected = ref false
 
-let hammer_main_tac env sigma gl l =
+let hammer_main_tac env sigma gl argus =
   let goal = get_goal gl in
   let hyps = get_hyps gl in
   let defs = get_defs env sigma in
-  let lems = get_argus env sigma l in
   if !Opt.debug_mode then
     Msg.info ("Found " ^ string_of_int (List.length defs) ^
                 " accessible Coq objects.");
   let info = 
-    if l = [] then
-      do_predict hyps defs goal
-    else
-      do_extraction hyps defs goal lems in
+    match argus with
+    | Prediction -> do_predict hyps defs goal
+    | Choice glems -> 
+        let lems = get_argus env sigma glems in
+        do_choice hyps defs goal lems 
+    in
   let (deps, defs, inverts) = get_tac_args env sigma info in
   let sdeps = List.map (Utils.constr_to_string sigma) deps
   and sdefs = List.map Utils.constant_to_string defs
@@ -856,7 +860,7 @@ let hammer_main_tac env sigma gl l =
       Msg.info ("Trying reconstruction batch " ^ string_of_int k ^ "...")
     end
 
-let hammer_tac l  =
+let hammer_tac argus =
   Proofview.Goal.enter
     begin fun gl ->
     let env = Proofview.Goal.env gl in
@@ -873,11 +877,11 @@ let hammer_tac l  =
               else
                 begin
                   provers_detected := true;
-                  hammer_main_tac env sigma gl l
+                  hammer_main_tac env sigma gl argus
                 end
             end
           else
-            hammer_main_tac env sigma gl l
+            hammer_main_tac env sigma gl argus
         end
       end
     end

--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -256,6 +256,15 @@ let get_defs env sigma : Hh_term.hhdef list =
   List.map snd (unique_hhdefs
                   (List.map (hhdef_of_global env sigma) (my_search env)))
 
+let get_argus env sigma l : Hh_term.hhdef list =
+  let argu_refs = 
+    List.map (fun c -> 
+      try let r, _ = Termops.global_of_constr sigma c in r
+      with _ -> raise (HammerError ("Argument " ^ (Utils.constr_to_string sigma c) ^ " not found in environment."))
+      ) l in
+  List.map snd (unique_hhdefs
+                  (List.map (hhdef_of_global env sigma) argu_refs))
+
 let ltac_timeout tm tac (args: Tacinterp.Value.t list) =
   Timeout.ptimeout tm (Utils.ltac_eval tac args)
 
@@ -722,6 +731,78 @@ let do_predict hyps deps goal =
     let deps1 = Features.predict hyps deps goal in
     Provers.predict deps1 hyps deps goal
 
+let do_extraction hyps deps goal lems =
+  if !Opt.gs_mode > 0 then
+    (* The last argument (0) is not used as a clustering parameter.
+       It's only a placeholder to reuse the function structure. *)
+    let greedy_sequence_lemmas =
+      [("CVC4", !Opt.cvc4_enabled, Opt.cvc4_enabled, "cvc4", 0);
+       ("Vampire", !Opt.vampire_enabled, Opt.vampire_enabled, "vampire", 0);
+       ("Eprover", !Opt.eprover_enabled, Opt.eprover_enabled, "eprover", 0);
+       ("Z3", !Opt.z3_enabled, Opt.z3_enabled, "z3", 0)]
+    in
+    let jobs seq =
+      List.map
+        begin fun (pname, enabled, pref, pred_method, preds_num) _ ->
+          if not enabled then
+            exit 1;
+          Opt.vampire_enabled := false;
+          Opt.eprover_enabled := false;
+          Opt.z3_enabled := false;
+          Opt.cvc4_enabled := false;
+          pref := true;
+          Opt.parallel_mode := false;
+          try
+            let deps1 = Features.extract_given_lemmas hyps deps lems goal pred_method in
+            (* All hypotheses are always passed to the ATPs (only deps
+               are subject to premise selection) *)
+            let info = Provers.predict deps1 hyps deps goal in
+            Msg.info (pname ^ " succeeded");
+            info
+          with
+          | HammerError(msg) ->
+             Msg.error ("Hammer error: " ^ msg);
+             exit 1
+          | _ ->
+             exit 1
+        end
+        (Hhlib.take !Opt.gs_mode (List.filter (fun (_, enabled, _, _, _) -> enabled) seq))
+    in
+    let time = (float_of_int !Opt.atp_timelimit) *. 1.5
+    in
+    Msg.info ("Running provers (" ^ string_of_int !Opt.gs_mode ^ " threads)...");
+    let clean () =
+      if not !Opt.debug_mode then
+        begin (* a hack *)
+          ignore (Sys.command ("rm -f " ^ Filename.get_temp_dir_name () ^ "/coqhammer*"))
+        end
+    in
+    let ret =
+        try
+          Parallel.run_parallel (fun _ -> ()) (fun _ -> ()) time (jobs greedy_sequence_lemmas)
+        with e ->
+          clean (); raise e
+    in
+    match ret with
+    | None -> clean (); raise (HammerFailure "ATPs failed to find a proof.\nYou may try increasing the ATP time limit with 'Set Hammer ATPLimit N' (default: 20s).")
+    | Some info ->
+       begin
+         let info =
+           if List.length info.Provers.deps >= !Opt.minimize_threshold then
+             Provers.minimize info hyps deps goal
+           else
+             info
+         in
+         clean ();
+         let msg = Provers.prn_atp_info info in
+         if msg <> "" then
+           Msg.info msg;
+         info
+       end
+  else (* Opts.gs_mode = 0 *)
+    let deps1 = Features.extract_given_lemmas hyps deps lems goal !Opt.predict_method in
+    Provers.predict deps1 hyps deps goal
+
 let try_sauto () =
   if !Opt.sauto_timelimit = 0 then
     Proofview.tclZERO (Failure "timeout")
@@ -739,14 +820,19 @@ let try_sauto () =
 
 let provers_detected = ref false
 
-let hammer_main_tac env sigma gl =
+let hammer_main_tac env sigma gl l =
   let goal = get_goal gl in
   let hyps = get_hyps gl in
   let defs = get_defs env sigma in
+  let lems = get_argus env sigma l in
   if !Opt.debug_mode then
     Msg.info ("Found " ^ string_of_int (List.length defs) ^
                 " accessible Coq objects.");
-  let info = do_predict hyps defs goal in
+  let info = 
+    if l = [] then
+      do_predict hyps defs goal
+    else
+      do_extraction hyps defs goal lems in
   let (deps, defs, inverts) = get_tac_args env sigma info in
   let sdeps = List.map (Utils.constr_to_string sigma) deps
   and sdefs = List.map Utils.constant_to_string defs
@@ -768,7 +854,7 @@ let hammer_main_tac env sigma gl =
       Msg.info ("Trying reconstruction batch " ^ string_of_int k ^ "...")
     end
 
-let hammer_tac () =
+let hammer_tac l  =
   Proofview.Goal.enter
     begin fun gl ->
     let env = Proofview.Goal.env gl in
@@ -785,11 +871,11 @@ let hammer_tac () =
               else
                 begin
                   provers_detected := true;
-                  hammer_main_tac env sigma gl
+                  hammer_main_tac env sigma gl l
                 end
             end
           else
-            hammer_main_tac env sigma gl
+            hammer_main_tac env sigma gl l
         end
       end
     end

--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -15,8 +15,8 @@ open Ltac_plugin
 module Utils = Hhutils
 
 (***************************************************************************************)
-type hammer_mode = 
-  | Prediction 
+type hammer_mode =
+  | Prediction
   | Choice of EConstr.t list
 
 let mk_id x = Hh_term.Id x
@@ -259,16 +259,20 @@ let get_defs env sigma : Hh_term.hhdef list =
   List.map snd (unique_hhdefs
                   (List.map (hhdef_of_global env sigma) (my_search env)))
 
-let get_argus env sigma l : Hh_term.hhdef list =
-  let argu_refs = 
-    List.map (fun c -> 
-      try let r, _ = Termops.global_of_constr sigma c in r
-      with
-      | Sys.Break -> raise Sys.Break
-      | _ -> raise (HammerError ("Argument " ^ (Utils.constr_to_string sigma c) ^ " not found in environment."))
-      ) l in
-  List.map snd (unique_hhdefs
-                  (List.map (hhdef_of_global env sigma) argu_refs))
+let get_given_lemmas env sigma l : Hh_term.hhdef list =
+  let get_lemma c =
+    let r =
+      try fst (EConstr.destRef sigma c)
+      with Constr.DestKO ->
+        raise (HammerError ("Lemma " ^ Utils.constr_to_string sigma c ^
+                              " not found in the environment."))
+    in
+    try hhdef_of_global env sigma r
+    with e when CErrors.noncritical e ->
+      raise (HammerError ("Lemma " ^ Utils.constr_to_string sigma c ^
+                            " cannot be used: " ^ Pp.string_of_ppcmds (CErrors.print e)))
+  in
+  List.map snd (unique_hhdefs (List.map get_lemma l))
 
 let ltac_timeout tm tac (args: Tacinterp.Value.t list) =
   Timeout.ptimeout tm (Utils.ltac_eval tac args)
@@ -645,6 +649,70 @@ let run_tactics deps defs inverts msg_success msg_fail msg_batch =
       hlp 1 tactics
     end
 
+let clean_temp_files () =
+  if not !Opt.debug_mode then
+    begin (* a hack *)
+      ignore (Sys.command ("rm -f " ^ Filename.get_temp_dir_name () ^ "/coqhammer*"))
+    end
+
+(* Runs jobs from `seq` in parallel, each invoking one ATP on the
+   premises returned by its selection function. Each element of `seq`
+   is: (prover description, enabled, enabled option ref, premise
+   selection function). *)
+let run_gs_provers hyps deps goal clean seq =
+  let jobs =
+    List.map
+      begin fun (pname, enabled, pref, select) _ ->
+        if not enabled then
+          exit 1;
+        Opt.vampire_enabled := false;
+        Opt.eprover_enabled := false;
+        Opt.z3_enabled := false;
+        Opt.cvc4_enabled := false;
+        pref := true;
+        Opt.parallel_mode := false;
+        try
+          let deps1 = select () in
+          (* All hypotheses are always passed to the ATPs (only deps
+             are subject to premise selection) *)
+          let info = Provers.predict deps1 hyps deps goal in
+          Msg.info (pname ^ " succeeded");
+          info
+        with
+        | HammerError(msg) ->
+           Msg.error ("Hammer error: " ^ msg);
+           exit 1
+        | _ ->
+           exit 1
+      end
+      (Hhlib.take !Opt.gs_mode (List.filter (fun (_, enabled, _, _) -> enabled) seq))
+  in
+  let time = (float_of_int !Opt.atp_timelimit) *. 1.5
+  in
+  Msg.info ("Running provers (" ^ string_of_int !Opt.gs_mode ^ " threads)...");
+  let ret =
+    try
+      Parallel.run_parallel (fun _ -> ()) (fun _ -> ()) time jobs
+    with e ->
+      clean (); raise e
+  in
+  match ret with
+  | None -> clean (); raise (HammerFailure "ATPs failed to find a proof.\nYou may try increasing the ATP time limit with 'Set Hammer ATPLimit N' (default: 20s).")
+  | Some info ->
+     begin
+       let info =
+         if List.length info.Provers.deps >= !Opt.minimize_threshold then
+           Provers.minimize info hyps deps goal
+         else
+           info
+       in
+       clean ();
+       let msg = Provers.prn_atp_info info in
+       if msg <> "" then
+         Msg.info msg;
+       info
+     end
+
 let do_predict hyps deps goal =
   if !Opt.gs_mode > 0 then
     let greedy_sequence =
@@ -673,139 +741,47 @@ let do_predict hyps deps goal =
        ("Z3 (nbayes-1024)", !Opt.z3_enabled, Opt.z3_enabled, "nbayes", 1024)]
     in
     let fname = Features.extract hyps deps goal in
-    let jobs =
+    let seq =
       List.map
-        begin fun (pname, enabled, pref, pred_method, preds_num) _ ->
-          if not enabled then
-            exit 1;
-          Opt.vampire_enabled := false;
-          Opt.eprover_enabled := false;
-          Opt.z3_enabled := false;
-          Opt.cvc4_enabled := false;
-          pref := true;
-          Opt.parallel_mode := false;
-          try
-            let deps1 = Features.run_predict fname deps preds_num pred_method in
-            (* All hypotheses are always passed to the ATPs (only deps
-               are subject to premise selection) *)
-            let info = Provers.predict deps1 hyps deps goal in
-            Msg.info (pname ^ " succeeded");
-            info
-          with
-          | HammerError(msg) ->
-             Msg.error ("Hammer error: " ^ msg);
-             exit 1
-          | _ ->
-             exit 1
+        begin fun (pname, enabled, pref, pred_method, preds_num) ->
+          (pname, enabled, pref,
+           fun () -> Features.run_predict fname deps preds_num pred_method)
         end
-        (Hhlib.take !Opt.gs_mode (List.filter (fun (_, enabled, _, _, _) -> enabled) greedy_sequence))
+        greedy_sequence
     in
-    let time = (float_of_int !Opt.atp_timelimit) *. 1.5
-    in
-    Msg.info ("Running provers (" ^ string_of_int !Opt.gs_mode ^ " threads)...");
     let clean () =
       Features.clean fname;
-      if not !Opt.debug_mode then
-        begin (* a hack *)
-          ignore (Sys.command ("rm -f " ^ Filename.get_temp_dir_name () ^ "/coqhammer*"))
-        end
+      clean_temp_files ()
     in
-    let ret =
-      try
-        Parallel.run_parallel (fun _ -> ()) (fun _ -> ()) time jobs
-      with e ->
-        clean (); raise e
-    in
-    match ret with
-    | None -> clean (); raise (HammerFailure "ATPs failed to find a proof.\nYou may try increasing the ATP time limit with 'Set Hammer ATPLimit N' (default: 20s).")
-    | Some info ->
-       begin
-         let info =
-           if List.length info.Provers.deps >= !Opt.minimize_threshold then
-             Provers.minimize info hyps deps goal
-           else
-             info
-         in
-         clean ();
-         let msg = Provers.prn_atp_info info in
-         if msg <> "" then
-           Msg.info msg;
-         info
-       end
+    run_gs_provers hyps deps goal clean seq
   else (* Opts.gs_mode = 0 *)
     let deps1 = Features.predict hyps deps goal in
     Provers.predict deps1 hyps deps goal
 
 let do_choice hyps deps goal lems =
+  (* The given lemmas must occur in the deps list: the ATP premises
+     are selected from it. They may be missing from the search
+     results, e.g. because of the search blacklist or a module
+     filter. *)
+  let deps =
+    let names = Hhlib.strset_from_lst (List.map Hh_term.get_hhdef_name deps) in
+    deps @
+      List.filter
+        (fun lem -> not (Hhlib.StringSet.mem (Hh_term.get_hhdef_name lem) names))
+        lems
+  in
+  let deps1 = Features.choose_given_lemmas hyps deps lems goal in
   if !Opt.gs_mode > 0 then
-    (* The last argument (0) is not used as a clustering parameter.
-       It's only a placeholder to reuse the function structure. *)
-    let greedy_sequence_lemmas =
-      [("CVC4", !Opt.cvc4_enabled, Opt.cvc4_enabled, "cvc4", 0);
-       ("Vampire", !Opt.vampire_enabled, Opt.vampire_enabled, "vampire", 0);
-       ("Eprover", !Opt.eprover_enabled, Opt.eprover_enabled, "eprover", 0);
-       ("Z3", !Opt.z3_enabled, Opt.z3_enabled, "z3", 0)]
-    in
-    let jobs seq =
+    let seq =
       List.map
-        begin fun (pname, enabled, pref, pred_method, preds_num) _ ->
-          if not enabled then
-            exit 1;
-          Opt.vampire_enabled := false;
-          Opt.eprover_enabled := false;
-          Opt.z3_enabled := false;
-          Opt.cvc4_enabled := false;
-          pref := true;
-          Opt.parallel_mode := false;
-          try
-            let deps1 = Features.choose_given_lemmas hyps deps lems goal pred_method in
-            (* All hypotheses are always passed to the ATPs (only deps
-               are subject to premise selection) *)
-            let info = Provers.predict deps1 hyps deps goal in
-            Msg.info (pname ^ " succeeded");
-            info
-          with
-          | HammerError(msg) ->
-             Msg.error ("Hammer error: " ^ msg);
-             exit 1
-          | _ ->
-             exit 1
-        end
-        (Hhlib.take !Opt.gs_mode (List.filter (fun (_, enabled, _, _, _) -> enabled) seq))
+        (fun (pname, enabled, pref) -> (pname, enabled, pref, fun () -> deps1))
+        [("CVC4", !Opt.cvc4_enabled, Opt.cvc4_enabled);
+         ("Vampire", !Opt.vampire_enabled, Opt.vampire_enabled);
+         ("Eprover", !Opt.eprover_enabled, Opt.eprover_enabled);
+         ("Z3", !Opt.z3_enabled, Opt.z3_enabled)]
     in
-    let time = (float_of_int !Opt.atp_timelimit) *. 1.5
-    in
-    Msg.info ("Running provers (" ^ string_of_int !Opt.gs_mode ^ " threads)...");
-    let clean () =
-      if not !Opt.debug_mode then
-        begin (* a hack *)
-          ignore (Sys.command ("rm -f " ^ Filename.get_temp_dir_name () ^ "/coqhammer*"))
-        end
-    in
-    let ret =
-        try
-          Parallel.run_parallel (fun _ -> ()) (fun _ -> ()) time (jobs greedy_sequence_lemmas)
-        with e ->
-          clean (); raise e
-    in
-    match ret with
-    | None -> clean (); raise (HammerFailure "ATPs failed to find a proof.\nYou may try increasing the ATP time limit with 'Set Hammer ATPLimit N' (default: 20s).")
-    | Some info ->
-       begin
-         let info =
-           if List.length info.Provers.deps >= !Opt.minimize_threshold then
-             Provers.minimize info hyps deps goal
-           else
-             info
-         in
-         clean ();
-         let msg = Provers.prn_atp_info info in
-         if msg <> "" then
-           Msg.info msg;
-         info
-       end
+    run_gs_provers hyps deps goal clean_temp_files seq
   else (* Opts.gs_mode = 0 *)
-    let deps1 = Features.choose_given_lemmas hyps deps lems goal !Opt.predict_method in
     Provers.predict deps1 hyps deps goal
 
 let try_sauto () =
@@ -825,20 +801,22 @@ let try_sauto () =
 
 let provers_detected = ref false
 
-let hammer_main_tac env sigma gl argus =
+let hammer_main_tac env sigma gl mode =
   let goal = get_goal gl in
   let hyps = get_hyps gl in
   let defs = get_defs env sigma in
   if !Opt.debug_mode then
     Msg.info ("Found " ^ string_of_int (List.length defs) ^
                 " accessible Coq objects.");
-  let info = 
-    match argus with
+  let info =
+    match mode with
     | Prediction -> do_predict hyps defs goal
-    | Choice glems -> 
-        let lems = get_argus env sigma glems in
-        do_choice hyps defs goal lems 
-    in
+    | Choice glems ->
+       (* An empty lemma list is allowed: then the premises are the
+          definitions directly referenced by the goal or the
+          hypotheses. *)
+       do_choice hyps defs goal (get_given_lemmas env sigma glems)
+  in
   let (deps, defs, inverts) = get_tac_args env sigma info in
   let sdeps = List.map (Utils.constr_to_string sigma) deps
   and sdefs = List.map Utils.constant_to_string defs
@@ -860,7 +838,7 @@ let hammer_main_tac env sigma gl argus =
       Msg.info ("Trying reconstruction batch " ^ string_of_int k ^ "...")
     end
 
-let hammer_tac argus =
+let hammer_tac mode =
   Proofview.Goal.enter
     begin fun gl ->
     let env = Proofview.Goal.env gl in
@@ -877,11 +855,11 @@ let hammer_tac argus =
               else
                 begin
                   provers_detected := true;
-                  hammer_main_tac env sigma gl argus
+                  hammer_main_tac env sigma gl mode
                 end
             end
           else
-            hammer_main_tac env sigma gl argus
+            hammer_main_tac env sigma gl mode
         end
       end
     end

--- a/src/plugin/hh_term.ml
+++ b/src/plugin/hh_term.ml
@@ -28,6 +28,14 @@ let get_hhdef_name ((c, _, _, _, _) : hhdef) : string =
 let hhdef_is_opaque ((_, opaque, _, _, _) : hhdef) : bool =
   opaque
 
+(* A variable (a section variable or a local hypothesis) is not a
+   global object: its name may denote something else in another
+   context. *)
+let hhdef_is_var ((c, _, _, _, _) : hhdef) : bool =
+  match c with
+  | Comb(Id "$Var", Id _) -> true
+  | _ -> false
+
 let rec string_of_hhterm t =
   match t with
   | Id(s) -> s

--- a/tests/plugin/Makefile
+++ b/tests/plugin/Makefile
@@ -1,6 +1,6 @@
 COQC=coqc
 
-all: transl.vo plugin_test.vo basic.vo bugs.vo hashing.vo arith.vo zarith.vo lists.vo misc.vo
+all: transl.vo plugin_test.vo lemma_choice.vo basic.vo bugs.vo hashing.vo arith.vo zarith.vo lists.vo misc.vo
 
 transl.vo: transl.v
 	$(COQC) transl.v > transl.out 2>&1
@@ -12,6 +12,9 @@ transl.vo: transl.v
 
 plugin_test.vo: plugin_test.v
 	$(COQC) plugin_test.v
+
+lemma_choice.vo: lemma_choice.v
+	$(COQC) lemma_choice.v
 
 basic.vo: basic.v
 	$(COQC) basic.v

--- a/tests/plugin/lemma_choice.v
+++ b/tests/plugin/lemma_choice.v
@@ -1,0 +1,70 @@
+(* Tests for the hammer lemma choice mode: hammer [lemma1 lemma2 ...] *)
+
+From Hammer Require Import Hammer.
+From Stdlib Require Import Lists.List.
+Import ListNotations.
+
+(* Disable the sauto pre-phase so that the lemma choice path is
+   actually exercised. *)
+Set Hammer SAutoLimit 0.
+
+Lemma lem_given : forall (A : Type) (l1 l2 : list A),
+  rev (l1 ++ l2) = rev l2 ++ rev l1.
+Proof.
+  intros.
+  induction l1.
+  - hammer [app_nil_r app_assoc].
+  - hammer [app_nil_r app_assoc].
+Qed.
+
+(* Duplicated lemmas are accepted. *)
+Lemma lem_duplicates : forall (A : Type) (l : list A), l ++ [] = l.
+Proof.
+  intros.
+  hammer [app_nil_r app_nil_r].
+Qed.
+
+(* A local hypothesis may be given as a lemma. *)
+Lemma lem_hyp : forall n : nat, n = 0 -> n + n = 0.
+Proof.
+  intros n H.
+  hammer [H].
+Qed.
+
+(* A lemma excluded from the search results (here by the search
+   blacklist) is still usable when given explicitly. *)
+Add Search Blacklist "app_nil_r".
+Lemma lem_blacklisted : forall (A : Type) (l : list A), rev (l ++ []) = rev l.
+Proof.
+  intros.
+  hammer [app_nil_r].
+Qed.
+Remove Search Blacklist "app_nil_r".
+
+(* An empty lemma list selects the definitions referenced by the goal
+   or the hypotheses: here the ATPs need the definition of `mydouble`,
+   which occurs only in the hypothesis. *)
+Definition mydouble (n : nat) := n + n.
+
+Lemma lem_empty : forall n m : nat, mydouble n = m -> n + n = m.
+Proof.
+  intros n m H.
+  hammer [].
+Qed.
+
+(* A term which is not a global reference is reported cleanly. *)
+Lemma lem_not_global : 1 + 1 = 2.
+Proof.
+  Fail hammer [(1 + 1)].
+  reflexivity.
+Qed.
+
+(* The lemma choice also works with GSMode 0. *)
+Set Hammer GSMode 0.
+
+Lemma lem_gsmode0 : forall (A B : Type) (f : A -> B) (l : list A),
+  length (map f l) = length l.
+Proof.
+  intros.
+  hammer [length_map].
+Qed.


### PR DESCRIPTION
Hello, CoqHammer is an excellent automated theorem proving tool that I have been using on Rocq. However, I notice that the current implementation only selects lemmas through clustering algorithms (by using `predict` command). This modification extends hammer to support user-specified lemmas.

I add support for an optional syntax to provide specific lemmas to the `hammer` tactic:
```coq
From Hammer Require Import Hammer.
From Stdlib Require Import Lists.List.
Import ListNotations.

Theorem demo: forall (A: Type) (l1 l2 : list A), 
  rev (l1 ++ l2) = rev l2 ++ rev l1.
Proof.
  intros.
  induction l1.
  - hammer [app_nil_r app_assoc_reverse_deprecated].
  - hammer [app_nil_r app_assoc_reverse_deprecated].
Qed.
```
The new syntax, `hammer [lemma1 lemma2 ...].`, allows users to explicitly specify which lemmas to use. I think this makes hammer more flexible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional lemma selection to `hammer` so users can steer premise choice. Default prediction mode remains unchanged, and a caching fix prevents variable-related misselection across proofs.

- **New Features**
  - New syntax: `hammer [lemma1 ...]` (also `[]`); plain `hammer` uses prediction.
  - Resolves names from the env; accepts duplicates and local hypotheses; clear errors for invalid/non-global terms.
  - Premises = given lemmas + defs referenced by the goal, hyps, and lemmas; given lemmas are injected into deps so ATPs see them even if search filters exclude them.
  - Works with GS mode (including GSMode 0); hyps are always passed; exposed as `Features.choose_given_lemmas`. Tests added.

- **Bug Fixes**
  - Do not cache features or dependencies for variables (local hyps/section vars), preventing stale cache reuse across proofs and ensuring fresh deps for goals and hypotheses.

<sup>Written for commit af279e899883da51d71a3d735c9da578d28c85fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

