### PR TITLE
Adapt to rocq-prover/rocq#21680 (tactic_of_value type change)

### DIFF
--- a/src/lib/hhutils.ml
+++ b/src/lib/hhutils.ml
@@ -5,9 +5,6 @@ open Ltac_plugin
 let intern_constr env evd cexpr =
   Constrintern.interp_constr_evars env evd cexpr
 
-let tacinterp tac =
-  Tacinterp.tactic_of_value (Tacinterp.default_ist ()) tac
-
 let to_constr r =
   match r with
   | Names.GlobRef.VarRef(v) -> EConstr.mkVar v

--- a/src/lib/hhutils.mli
+++ b/src/lib/hhutils.mli
@@ -4,8 +4,6 @@ open Ltac_plugin
 val intern_constr : Environ.env -> Evd.evar_map -> Constrexpr.constr_expr ->
                     Evd.evar_map * EConstr.t
 
-val tacinterp : Geninterp.Val.t -> unit Proofview.tactic
-
 val exists_global : string -> bool
 
 val match_globref : ModPath.t -> GlobRef.t -> bool

--- a/src/tactics/g_hammer_tactics.mlg
+++ b/src/tactics/g_hammer_tactics.mlg
@@ -160,7 +160,7 @@ TACTIC EXTEND Hammer_srun
 | [ "srun" tactic4(tac) sauto_opts(l) ] -> {
   try_usolve (default_s_opts ()) l
     (fun opts -> sinit opts <*>
-                   Tacticals.tclSOLVE [ Hhutils.tacinterp tac ])
+                   Tacticals.tclSOLVE [ Tacinterp.tactic_of_value ist tac ])
     "srun failed"
 }
 END


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adapt to `rocq-prover/rocq#21680` where `Tacinterp.tactic_of_value` now requires an interpreter state. Restores build compatibility with the latest Rocq; no behavior change.

- **Refactors**
  - Removed `Hhutils.tacinterp` and its `mli` entry.
  - Updated `Hammer_srun` to call `Tacinterp.tactic_of_value ist tac` directly.

<sup>Written for commit a1c61b77119087dd9104a869c9c6e578ce71c17c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

