### PR TITLE
Adapt to rocq-prover/rocq#21767 (qglobal is not qvar)

### DIFF
--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -35,7 +35,7 @@ let hhterm_of_sort s = match s with
   | Prop -> mk_id "$Prop"
   | Set  -> mk_id "$Set"
   | Type _ -> mk_id "$Type"
-  | QSort _ -> mk_id "$Type"
+  | GSort _ | VSort _ -> mk_id "$Type"
 
 let hhterm_of_constant c =
   tuple [mk_id "$Const"; hhterm_of_global (Names.GlobRef.ConstRef c)]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adapts Hammer to the latest `rocq` sort API from rocq-prover/rocq#21767 by replacing `QSort` with `GSort` and `VSort`; both map to `$Type` to preserve behavior.

<sup>Written for commit 06fa3d23e519f16a816a397d1a1b86a826c5aaf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

