### PR TITLE
Adapt to rocq-prover/rocq#22114.

### DIFF
--- a/src/lib/hhutils.ml
+++ b/src/lib/hhutils.ml
@@ -675,7 +675,7 @@ let hint_to_string (_, _, h) =
 let find_hints db secvars env evd t =
   try
     let open Hints in
-    let hdc = Hints.decompose_app_bound evd t in
+    let hdc = Hints.decompose_app_bound env evd t in
     let hints =
       if Termops.occur_existential evd t then
         match Hint_db.map_eauto env evd ~secvars hdc t db with

--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -92,7 +92,7 @@ let rec hhterm_of (t : Constr.t) : Hh_term.hhterm =
      tuple [mk_id "$App"; hhterm_of f; hhterm_of_constrarray args]
   | Const (c,u)       -> hhterm_of_constant c
   | Proj (p,_,c)        -> tuple [mk_id "$Proj";
-                                hhterm_of_constant (Projection.constant p);
+                                mk_id (string_of_int (Projection.arg p));
                                 hhterm_of_bool (Projection.unfolded p);
                                 hhterm_of c]
   | Evar (evk,cl)     -> raise (HammerError "Existential variables not supported.")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adapt to API changes from `rocq-prover/rocq` PR #22114 to keep the build green. Pass `env` to `Hints.decompose_app_bound`, and replace `Projection.constant` with the `Projection.arg` index (stringified) while keeping `Projection.unfolded`.

<sup>Written for commit bea91da82082d0836841e671b9de724e7eefe419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

