### PR TITLE
Fix issue #130: prover detection must not override explicit selection

### DIFF
--- a/src/plugin/provers.ml
+++ b/src/plugin/provers.ml
@@ -497,7 +497,6 @@ let detect_eprover () =
   if Sys.command "eprover --version 2>&1 >/dev/null" = 0 then
     begin
       Msg.info "Eprover found";
-      Opt.eprover_enabled := true;
       true
     end
   else
@@ -511,7 +510,6 @@ let detect_vampire () =
   if Sys.command "vampire --version 2>&1 >/dev/null" = 0 then
     begin
       Msg.info "Vampire found";
-      Opt.vampire_enabled := true;
       true
     end
   else
@@ -547,14 +545,12 @@ let detect_z3 () =
     begin
       z3_binary := Z3Tptp;
       Msg.info "Z3 found (z3_tptp)";
-      Opt.z3_enabled := true;
       true
     end
   else if command_succeeds "z3 -h" && z3_supports_tptp Z3 then
     begin
       z3_binary := Z3;
       Msg.info "Z3 found (z3 with TPTP support)";
-      Opt.z3_enabled := true;
       true
     end
   else
@@ -568,7 +564,6 @@ let detect_cvc4 () =
   if Sys.command "cvc4 --version 2>&1 >/dev/null" = 0 then
     begin
       Msg.info "CVC4 found";
-      Opt.cvc4_enabled := true;
       true
     end
   else

--- a/tests/plugin/Makefile
+++ b/tests/plugin/Makefile
@@ -1,6 +1,6 @@
 COQC=coqc
 
-all: transl.vo plugin_test.vo lemma_choice.vo basic.vo bugs.vo hashing.vo arith.vo zarith.vo lists.vo misc.vo
+all: transl.vo plugin_test.vo lemma_choice.vo basic.vo bugs.vo prover_selection.vo hashing.vo arith.vo zarith.vo lists.vo misc.vo
 
 transl.vo: transl.v
 	$(COQC) transl.v > transl.out 2>&1
@@ -21,6 +21,9 @@ basic.vo: basic.v
 
 bugs.vo: bugs.v
 	$(COQC) bugs.v
+
+prover_selection.vo: prover_selection.v
+	$(COQC) prover_selection.v
 
 hashing.vo: hashing.v
 	$(COQC) hashing.v

--- a/tests/plugin/prover_selection.v
+++ b/tests/plugin/prover_selection.v
@@ -1,0 +1,29 @@
+(* Regression test for issue #130.
+
+   Prover detection runs lazily, on the first invocation of `hammer` in a
+   file.  It must not clobber an explicit prover selection (Set/Unset Hammer
+   <Prover>) made before that first invocation: detection may only disable a
+   prover whose binary is missing, never re-enable one the user turned off.
+
+   We check the prover-agnostic invariant: with every ATP disabled before the
+   first `hammer` call, `hammer` must fail (no prover is enabled to run).
+   Before the fix, detection re-enabled every installed prover, so `hammer`
+   wrongly succeeded.  Note we cannot assert on `Test Hammer <Prover>`: Coq
+   restores the declared option value at command boundaries, hiding the direct
+   mutation made by detection. *)
+
+From Hammer Require Import Hammer.
+From Stdlib Require Import Arith.
+
+Set Hammer GSMode 0.
+Unset Hammer Parallel.
+Set Hammer SAutoLimit 0.
+
+Unset Hammer Vampire.
+Unset Hammer Z3.
+Unset Hammer Eprover.
+Unset Hammer CVC4.
+
+Goal le 1 2.
+  Fail hammer.
+Abort.


### PR DESCRIPTION
## Summary

Fixes #130.

Prover detection runs lazily, on the first `hammer` invocation in a file — which is *after* any `Set`/`Unset Hammer <Prover>` command. Its "found" branches wrote `Opt.<prover>_enabled := true`, clobbering an explicit selection the user had made beforehand. So `Unset Hammer Vampire` (etc.) was silently reverted the moment `hammer` first ran.

Detection now only *disables* provers whose binary is missing, and never *re-enables* one the user turned off. The `:= false` assignments in the "not found" branches are kept (a missing binary cannot run), as is `z3_binary := ...` (needed to select the z3 invocation style).

## Test

Adds `tests/plugin/prover_selection.v`: with every ATP `Unset` before the first `hammer`, `hammer` must fail (no prover enabled to run). The test asserts the prover-agnostic invariant rather than `Test Hammer <Prover>`, because Coq restores declared option values at command boundaries, hiding the direct mutation made by detection.

Verified locally with all four ATPs installed:
- With the fix: the regression test passes; a normal `hammer` on default-enabled provers still proves its goal.
- Reverting the fix makes the test fail as designed (detection re-enables Vampire, which proves the goal, so `Fail hammer` errors).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop prover detection from re-enabling provers users turned off, so explicit `Unset Hammer <Prover>` is respected on the first `hammer` call. Fixes #130.

- **Bug Fixes**
  - Detection no longer sets `Opt.{eprover,vampire,z3,cvc4}_enabled := true`; it only disables a prover if its binary is missing. Keeps `z3_binary` selection for invocation style.
  - Adds `tests/plugin/prover_selection.v` and Makefile rule to assert `hammer` fails when all provers are unset before first run.

<sup>Written for commit 52bb609a7d659c71d3e5f0ace02588079abce80f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

