### PR TITLE
Clear error when the predict binary is not found

### DIFF
--- a/src/plugin/features.ml
+++ b/src/plugin/features.ml
@@ -255,9 +255,22 @@ let run_predict fname defs pred_num pred_method =
                  string_of_int pred_num ^ ")...");
   if !Opt.debug_mode then
     Msg.info cmd;
-  if Sys.command cmd <> 0 then
+  let ret = Sys.command cmd in
+  if ret <> 0 then
     begin
-      raise (HammerError ("Dependency prediction failed.\nPrediction command: " ^ cmd))
+      (* sh exits with 127 when the command cannot be found *)
+      let hint =
+        if ret = 127 then
+          "\nThe '" ^ !Opt.predict_path ^
+            "' program could not be found. Most probably it is not installed \
+             or not in the PATH. Note that the PATH seen by CoqHammer may \
+             differ from your shell's PATH (e.g. when Rocq is started from an \
+             IDE); see the CoqHammer installation instructions."
+        else
+          ""
+      in
+      raise (HammerError ("Dependency prediction failed." ^ hint ^
+                            "\nPrediction command: " ^ cmd))
     end;
   let ic = open_in oname in
   try

--- a/src/plugin/features.ml
+++ b/src/plugin/features.ml
@@ -269,6 +269,7 @@ let run_predict fname defs pred_num pred_method =
         else
           ""
       in
+      Sys.remove oname;
       raise (HammerError ("Dependency prediction failed." ^ hint ^
                             "\nPrediction command: " ^ cmd ^
                             (if !Opt.debug_mode then

--- a/tests/tactics/tactics_test.v
+++ b/tests/tactics/tactics_test.v
@@ -1705,7 +1705,7 @@ End MergeSort.
 
 Lemma lem_issue_183_1 : (forall P : Prop, P) /\ True.
 Proof.
-  Fail srun ltac:(split; [ shelve | exact I ]).
+  Fail srun (split; [ shelve | exact I ]).
   Fail qauto.
   Fail hauto.
   Fail sauto.


### PR DESCRIPTION
## Summary

When dependency prediction fails because the `predict` binary is not on the `PATH`, CoqHammer only printed the failing command line, giving no clue about the cause. The reporter of #138 spent hours discovering that the shell's `PATH` (as seen when Rocq is started from an IDE such as Proof General) did not contain `predict`.

This detects the shell's `command not found` exit code (127) and appends a hint to the error:

> The 'predict' program could not be found. Most probably it is not installed or not in the PATH. Note that the PATH seen by CoqHammer may differ from your shell's PATH (e.g. when Rocq is started from an IDE); see the CoqHammer installation instructions.

Notes:
- The hint only appears for the not-found case (exit 127); other failures keep the plain message plus the command line.
- It uses the configured `predict_path`, so a custom predictor path is named correctly.

Fixes #138

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a clear error when the `predict` binary is missing by detecting exit code 127 and appending a hint about installation/PATH, using the configured `predict_path`. Fixes #138.

- **Bug Fixes**
  - Detect exit code 127 and add a hint; PATH may differ when Rocq runs from an IDE.
  - Preserve command line and debug log pointer; clean up temp output on failure; fix `srun` test syntax (issue #183) so tests run.

<sup>Written for commit 676366242bda3e184f30bc25842fc3f4df2bd5e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

