### PR TITLE
Add regression test for issue #134 (sauto universe-constraint anomaly)

### DIFF
--- a/tests/tactics/tactics_test.v
+++ b/tests/tactics/tactics_test.v
@@ -1660,3 +1660,36 @@ Next Obligation.
 Defined.
 
 End MergeSort.
+
+(* Regression test for issue #134: on older Rocq versions sauto raised
+   Anomaly "Unable to handle arbitrary u+k <= v constraints." on goals
+   mentioning a section variable of a class with a let-field, when the
+   definition and the lemma live in different sections. *)
+
+Class ExternSem := {
+  extern_state : Type;
+  AbsMet := extern_state -> extern_state -> Prop
+}.
+
+Section EXT.
+  Context {target : ExternSem}.
+  (* Logic.and / Logic.True are qualified because [and] is shadowed by a
+     boolean definition earlier in this test file. *)
+  Definition EXT (a : list (extern_state -> Prop)) (es : extern_state) : Prop :=
+    fold_right Logic.and Logic.True (map (fun (ep : extern_state -> Prop) => (ep es)) a).
+End EXT.
+
+Section ExtExtract.
+  Context {target : ExternSem}.
+  Fixpoint remove_nth {A} (n : nat) (al : list A) {struct n} : list A :=
+    match n, al with
+    | O, a :: al => al
+    | S n', a :: al' => a :: remove_nth n' al'
+    | _, nil => nil
+    end.
+
+  Lemma lem_issue_134 : forall n es, EXT (remove_nth n nil) es.
+  Proof.
+    sauto.
+  Qed.
+End ExtExtract.


### PR DESCRIPTION
Closes #134.

## Summary

`sauto` used to raise `Anomaly "Unable to handle arbitrary u+k <= v constraints."` on goals mentioning a section variable of a class with a let-field, when the definition and the lemma live in different sections (reduced from petr4/poulet4).

On **Rocq 9.1 the bug no longer reproduces**: the offending kernel spot in `engine/univSubst.ml` now raises a *catchable* `CErrors.user_err` instead of a *critical* `CErrors.anomaly`. A critical anomaly raised mid-tactic bypasses the CPS backtracking monad entirely (`tclOR`/`tclORELSE`/`catch_failerror` and `wrap_exceptions` only handle noncritical exceptions), which is why it previously escaped `sauto` — and why even `Fail sauto` re-raised it. There is no in-tactic way to intercept a critical anomaly, so this could only ever be resolved in the kernel; on 9.1 it is.

This PR adds a regression test capturing the minimal cross-section example so the behavior stays locked in.

## Changes

- `tests/tactics/tactics_test.v`: new `lem_issue_134` regression test (tests only, no source change). `Logic.and`/`Logic.True` are qualified because the test file defines a boolean `and` earlier.

## Testing

- `make test-tactics` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test for issue #134 to ensure `sauto` handles cross-section lemmas with a class let-field without raising the universe-constraint anomaly. On Rocq 9.1 the scenario succeeds; this test locks in that behavior.

- **New Features**
  - Adds `lem_issue_134` in `tests/tactics/tactics_test.v` to validate `sauto` on the minimal cross-section example.
  - Qualifies `Logic.and` and `Logic.True` to avoid shadowing in the test file.

<sup>Written for commit b66d0b5c9cda702af8ed383940a63822ba70653c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

