### PR TITLE
Log external command stderr to a file in debug mode

### DIFF
--- a/src/plugin/features.ml
+++ b/src/plugin/features.ml
@@ -259,7 +259,7 @@ let run_predict fname defs pred_num pred_method =
     begin
       raise (HammerError ("Dependency prediction failed.\nPrediction command: " ^ cmd ^
                           (if !Opt.debug_mode then
-                             "\nSee '" ^ Opt.error_log_file ^ "' for the error output."
+                             "\nSee '" ^ Opt.error_log_file () ^ "' for the error output."
                            else "")))
     end;
   let ic = open_in oname in

--- a/src/plugin/features.ml
+++ b/src/plugin/features.ml
@@ -247,7 +247,7 @@ let run_predict fname defs pred_num pred_method =
   let oname = Filename.temp_file ("coqhammer_out" ^ pred_method ^ string_of_int pred_num) "" in
   let cmd = !Opt.predict_path ^ " " ^ fname ^ "fea " ^ fname ^ "dep " ^
     fname ^ "seq -n " ^ string_of_int pred_num ^
-    " -p " ^ pred_method ^ " 2>/dev/null < " ^ fname ^
+    " -p " ^ pred_method ^ " " ^ Opt.stderr_redirect () ^ " < " ^ fname ^
     "conj > " ^ oname
   in
   if !Opt.debug_mode || !Opt.gs_mode = 0 then
@@ -257,7 +257,10 @@ let run_predict fname defs pred_num pred_method =
     Msg.info cmd;
   if Sys.command cmd <> 0 then
     begin
-      raise (HammerError ("Dependency prediction failed.\nPrediction command: " ^ cmd))
+      raise (HammerError ("Dependency prediction failed.\nPrediction command: " ^ cmd ^
+                          (if !Opt.debug_mode then
+                             "\nSee '" ^ Opt.error_log_file ^ "' for the error output."
+                           else "")))
     end;
   let ic = open_in oname in
   try

--- a/src/plugin/opt.ml
+++ b/src/plugin/opt.ml
@@ -192,6 +192,20 @@ let _ =
   in
   declare_bool_option gdopt
 
+(* File the stderr of external commands (the predictor and the ATPs) is
+   appended to when debugging is on. *)
+let error_log_file =
+  Filename.concat (Filename.get_temp_dir_name ()) "coqhammer_error.log"
+
+(* Shell redirection for the stderr of external commands: in debug mode
+   the error output is kept in `error_log_file` so that configuration
+   problems can be diagnosed; otherwise it is discarded. *)
+let stderr_redirect () =
+  if !debug_mode then
+    "2>> " ^ Filename.quote error_log_file
+  else
+    "2>/dev/null"
+
 let _ =
   let gdopt=
     { optdepr=None;

--- a/src/plugin/opt.ml
+++ b/src/plugin/opt.ml
@@ -192,17 +192,27 @@ let _ =
   in
   declare_bool_option gdopt
 
-(* File the stderr of external commands (the predictor and the ATPs) is
-   appended to when debugging is on. *)
-let error_log_file =
-  Filename.concat (Filename.get_temp_dir_name ()) "coqhammer_error.log"
+let error_log_file_ref = ref None
+
+(* Path of the log file collecting the stderr of external commands (the
+   predictor and the ATPs) in debug mode. A fresh, user-owned temporary
+   file with safe permissions is created on first use, so the
+   redirection cannot be diverted to a pre-existing attacker-controlled
+   path in the shared temp directory. *)
+let error_log_file () =
+  match !error_log_file_ref with
+  | Some f -> f
+  | None ->
+     let f = Filename.temp_file "coqhammer_error" ".log" in
+     error_log_file_ref := Some f;
+     f
 
 (* Shell redirection for the stderr of external commands: in debug mode
-   the error output is kept in `error_log_file` so that configuration
+   the error output is kept in the error log file so that configuration
    problems can be diagnosed; otherwise it is discarded. *)
 let stderr_redirect () =
   if !debug_mode then
-    "2>> " ^ Filename.quote error_log_file
+    "2>> " ^ Filename.quote (error_log_file ())
   else
     "2>/dev/null"
 

--- a/src/plugin/provers.ml
+++ b/src/plugin/provers.ml
@@ -166,7 +166,7 @@ let invoke_prover prover_name cmd outfile =
       if !Opt.debug_mode then
         begin
           Msg.info ("Return code: " ^ string_of_int ret);
-          Msg.info ("See '" ^ Opt.error_log_file ^ "' for the error output.")
+          Msg.info ("See '" ^ Opt.error_log_file () ^ "' for the error output.")
         end;
       false
     end
@@ -369,6 +369,10 @@ let call_provers fname ofname =
   pom provers
 
 let call_provers_par fname ofname =
+  (* Allocate the debug log in the parent so that the forked workers
+     below all append to the same file. *)
+  if !Opt.debug_mode then
+    ignore (Opt.error_log_file ());
   let jobs =
     List.map
       begin fun ((_, pname, _, _) as h) _ ->

--- a/src/plugin/provers.ml
+++ b/src/plugin/provers.ml
@@ -164,7 +164,10 @@ let invoke_prover prover_name cmd outfile =
     begin
       Msg.error ("Error running " ^ prover_name ^ ".");
       if !Opt.debug_mode then
-        Msg.info ("Return code: " ^ string_of_int ret);
+        begin
+          Msg.info ("Return code: " ^ string_of_int ret);
+          Msg.info ("See '" ^ Opt.error_log_file ^ "' for the error output.")
+        end;
       false
     end
   else
@@ -174,7 +177,7 @@ let call_eprover infile outfile =
   let tmt = string_of_int !Opt.atp_timelimit in
   let tmt2 = string_of_int (!Opt.atp_timelimit + 1) in
   let cmd =
-    "htimeout " ^ tmt2 ^ " eprover -s --cpu-limit=" ^ tmt ^ " --auto-schedule -R --print-statistics -p --tstp-format \"" ^ infile ^ "\" 2>/dev/null | grep \"file[(]'\\|# SZS\" > \"" ^ outfile ^ "\""
+    "htimeout " ^ tmt2 ^ " eprover -s --cpu-limit=" ^ tmt ^ " --auto-schedule -R --print-statistics -p --tstp-format \"" ^ infile ^ "\" " ^ Opt.stderr_redirect () ^ " | grep \"file[(]'\\|# SZS\" > \"" ^ outfile ^ "\""
   in
   invoke_prover "eprover" cmd outfile
 
@@ -228,7 +231,7 @@ let call_z3 infile outfile =
   let bin = !z3_binary in
   let cmd =
     "htimeout " ^ tmt2 ^ " " ^ z3_name bin ^ " " ^ z3_call_args bin infile ^
-      " 2>/dev/null > " ^ Filename.quote outfile
+      " " ^ Opt.stderr_redirect () ^ " > " ^ Filename.quote outfile
   in
   invoke_prover (z3_name bin) cmd outfile
 
@@ -249,7 +252,7 @@ let call_vampire infile outfile =
   let tmt = string_of_int !Opt.atp_timelimit in
   let tmt2 = string_of_int (!Opt.atp_timelimit + 1) in
   let cmd =
-    "htimeout " ^ tmt2 ^ " vampire --mode casc -t " ^ tmt ^ " --proof tptp --output_axiom_names on " ^ infile ^ " 2>/dev/null | grep \"file[(]'\\|% SZS\" > " ^ outfile
+    "htimeout " ^ tmt2 ^ " vampire --mode casc -t " ^ tmt ^ " --proof tptp --output_axiom_names on " ^ infile ^ " " ^ Opt.stderr_redirect () ^ " | grep \"file[(]'\\|% SZS\" > " ^ outfile
   in
   invoke_prover "vampire" cmd outfile
 


### PR DESCRIPTION
## Summary

Fixes #140.

External commands run by hammer — the `predict` binary and the ATPs (eprover, z3, vampire) — discarded their stderr with `2>/dev/null`. This made diagnosing configuration problems (e.g. a misconfigured prover on the user's system) harder than necessary, since the actual error output was thrown away.

Now stderr redirection is controlled by `Set Hammer Debug`:

- **Debug off** (default): unchanged — stderr discarded.
- **Debug on**: stderr from all external commands is appended to `$TMPDIR/coqhammer_error.log`, and prover/prediction failure messages point at that file.

## Changes

- `src/plugin/opt.ml` — add `error_log_file` and a `stderr_redirect ()` helper next to the existing `Hammer Debug` option.
- `src/plugin/features.ml`, `src/plugin/provers.ml` — route the four external-command call sites (predict, eprover, z3, vampire) through `Opt.stderr_redirect ()` instead of a hardcoded `2>/dev/null`; mention the log file on failure.

## Notes

- Uses append (`2>>`) since provers run in parallel and share the file within a run; the log accumulates across runs in a debug session. The file lives under `$TMPDIR` with a `coqhammer` prefix so the existing non-debug `clean_temp_files` removes it automatically and leaves it in place in debug mode.
- `call_cvc4` was left alone: it doesn't redirect stderr at all (goes to the terminal), so it isn't part of the reported problem.

Plugin builds cleanly (only pre-existing deprecation warnings).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log stderr from external commands to a private temp file when Hammer Debug is on to make configuration issues easy to diagnose (fixes #140). Default behavior stays the same: stderr is discarded.

- **Bug Fixes**
  - Added `Opt.error_log_file ()` and `Opt.stderr_redirect ()`; in Debug, stderr appends to a private temp log with safe permissions; otherwise it’s discarded.
  - Applied to predictor and ATPs; failure messages now point to the log file.
  - For parallel runs, allocate the log in the parent so workers share one file; use append redirection.

<sup>Written for commit 6a78afdca9f6d29bd6e8718f823981e565703344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

