### PR TITLE
Fix srun option syntax error in reconstruction suggestions (#144)

### DIFF
--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -553,7 +553,7 @@ let run_tactics deps defs inverts msg_success msg_fail msg_batch =
               Utils.ltac_apply "Reconstr.qrrexhaustive1" [])
   in
   let pretactics =
-    [ (reauto, "srun eauto"); (rcongruence, "scongruence");
+    [ (reauto, "srun (eauto)"); (rcongruence, "scongruence");
       (rtrivial, "strivial"); (rfirstorder, "sfirstorder") ]
   in
   let tactics = [
@@ -598,18 +598,18 @@ let run_tactics deps defs inverts msg_success msg_fail msg_batch =
     catch_errors
       begin fun () ->
         tactics @
-          [ [ (rreasy (), "srun Reconstr.rreasy");
-              (rrsimple (), "srun Reconstr.rrsimple");
-              (rrcrush (), "srun Reconstr.rrcrush");
-              (rryelles4 (), "srun Reconstr.rryelles4") ];
-            [ (rrblast (), "srun Reconstr.rrblast");
-              (rrscrush (), "srun Reconstr.rrscrush");
-              (rryreconstr (), "srun Reconstr.rryreconstr");
-              (rrhreconstr4 (), "srun Reconstr.rrhreconstr4") ];
-            [ (rryelles6 (), "srun Reconstr.rryelles6");
-              (rrhreconstr6 (), "srun Reconstr.rrhreconstr6");
-              (rrhrauto4 (), "srun Reconstr.rrhrauto4");
-              (rrexhaustive1 (), "srun Reconstr.rrexhaustive1") ] ]
+          [ [ (rreasy (), "srun (Reconstr.rreasy)");
+              (rrsimple (), "srun (Reconstr.rrsimple)");
+              (rrcrush (), "srun (Reconstr.rrcrush)");
+              (rryelles4 (), "srun (Reconstr.rryelles4)") ];
+            [ (rrblast (), "srun (Reconstr.rrblast)");
+              (rrscrush (), "srun (Reconstr.rrscrush)");
+              (rryreconstr (), "srun (Reconstr.rryreconstr)");
+              (rrhreconstr4 (), "srun (Reconstr.rrhreconstr4)") ];
+            [ (rryelles6 (), "srun (Reconstr.rryelles6)");
+              (rrhreconstr6 (), "srun (Reconstr.rrhreconstr6)");
+              (rrhrauto4 (), "srun (Reconstr.rrhrauto4)");
+              (rrexhaustive1 (), "srun (Reconstr.rrexhaustive1)") ] ]
       end
       (fun _ -> tactics)
   in

--- a/src/tactics/g_hammer_tactics.mlg
+++ b/src/tactics/g_hammer_tactics.mlg
@@ -157,7 +157,7 @@ TACTIC EXTEND Hammer_sunfolding
 END
 
 TACTIC EXTEND Hammer_srun
-| [ "srun" tactic4(tac) sauto_opts(l) ] -> {
+| [ "srun" tactic0(tac) sauto_opts(l) ] -> {
   try_usolve (default_s_opts ()) l
     (fun opts -> sinit opts <*>
                    Tacticals.tclSOLVE [ Hhutils.tacinterp tac ])

--- a/tests/tactics/tactics_test.v
+++ b/tests/tactics/tactics_test.v
@@ -38,6 +38,34 @@ Proof.
   hauto.
 Qed.
 
+(* srun takes a tactic at level 0, so a simple tactic followed by sauto
+   options need not be parenthesised (a compound tactic still does). *)
+
+Definition srun_p (n : nat) := n = n.
+
+Lemma srun_lem : forall n, srun_p n.
+Proof. unfold srun_p; auto. Qed.
+
+Lemma lem_test_srun_1 : forall n : nat, srun_p n.
+Proof.
+  srun eauto use: srun_lem.
+Qed.
+
+Lemma lem_test_srun_2 : forall n : nat, srun_p n.
+Proof.
+  srun (eauto) use: srun_lem.
+Qed.
+
+Lemma lem_test_srun_3 : forall n : nat, srun_p n.
+Proof.
+  srun eauto unfold: srun_p.
+Qed.
+
+Lemma lem_test_srun_4 : forall n : nat, srun_p n.
+Proof.
+  srun (idtac; eauto) use: srun_lem.
+Qed.
+
 Definition feq (x y z : nat) : Prop := x + y + z = x * y + z.
 
 Lemma lem_sym_feq : (forall x y z, feq x y z) -> forall x y z, x * y + z = x + y + z.


### PR DESCRIPTION
## Problem

On newer Rocq, pasting a hammer reconstruction suggestion such as

```
srun eauto use: binds_neq_shrink unfold: term_subst, subst, prop_subst.
```

fails with:

```
Error: Syntax error: [ltac_use_default] expected after [tactic] (in [tactic_command]).
```

This worked on older Coq. Wrapping the tactic in parentheses — `srun (eauto) use: ...` — is a known workaround (see issue #144).

## Root cause

`srun` parsed its tactic argument with `tactic4` (`ltac_expr` level 4). At levels ≥ 1 a bare tactic name is parsed by the greedy `reference; LIST0 tactic_arg` production. Since the option keywords (`use`, `unfold`, ...) are ordinary identifiers, not reserved keywords, that production swallows the following `use` as a constr argument and then chokes on the `:`. Older Rocq registered those words as keywords, which blocked the greedy parse; current Rocq does not.

## Fix

Two changes:

1. **Emit parenthesised suggestions.** The hammer now prints `srun (eauto) ...` / `srun (Reconstr.rr...) ...`, matching the form already used throughout `examples/`. This parses regardless of the grammar level.

2. **Parse the `srun` tactic argument at level 0** (`tactic0`). `tactic_atom` parses a reference with an empty argument list, so parsing stops before the options. A simple tactic followed by sauto options no longer needs parentheses:

   - `srun eauto use: lem` — now works unparenthesised
   - `srun (eauto) use: lem` — still works
   - Compound tactics (`try`, `;`, `+`, `||`) must now be parenthesised, e.g. `srun (idtac; eauto) use: lem`. This is rare with `srun`.

## Tests

Added four `srun` regression cases to `tests/tactics/tactics_test.v` covering the unparenthesised simple-tactic form, the parenthesised form, `unfold:`, and a parenthesised compound tactic. `tactics_test.v` and `legacy_tactics_test.v` pass; the plugin rebuilds against the updated tactics.

## Note (not addressed here)

The same greedy-consumption issue affects the tactic-valued sauto options (`solve:`, `simp:`, `ssimp:`, `finish:`, `final:` and the `+` variants), which still use `tactic4`. The identical `tactic0` fix would apply if desired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a syntax error on newer Rocq where `srun eauto use: ...` failed by changing how `srun` parses its tactic and by emitting parenthesized suggestions. Also adds regression tests to cover the new behavior (addresses #144).

- **Bug Fixes**
  - Parse `srun` tactic at `tactic0` to prevent greedy consumption of option keywords (`use:`, `unfold:`).
  - Hammer now prints `srun (eauto) ...` and `srun (Reconstr.rr...) ...` in suggestions for consistent parsing across Rocq versions.
  - Simple tactics now work without parentheses (`srun eauto use: lem`); compound tactics must be parenthesized (`srun (idtac; eauto) ...`).
  - Added four regression tests for unparenthesized/parenthesized forms and `unfold:`.

<sup>Written for commit 4bcc0339d32cb9b772c82df41d436edf380ea377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

