### PR TITLE
Resolve notations for applied inductives in sauto option arguments

### DIFF
--- a/src/lib/hhutils.ml
+++ b/src/lib/hhutils.ml
@@ -55,7 +55,10 @@ let get_inductive_from_id id =
   | _ -> failwith "not an inductive type"
 
 let get_inductive_from_qualid q =
-  match Smartlocate.global_with_alias q with
+  (* [~head:true] resolves abbreviations that expand to a (partially) applied
+     inductive, e.g. [Notation Forall := Forall] or [Notation P := (@Q nat)],
+     to the head inductive. *)
+  match Smartlocate.global_with_alias ~head:true q with
   | Names.GlobRef.IndRef(i) -> i
   | _ -> failwith "not an inductive type"
 
@@ -70,7 +73,9 @@ let get_const_from_id id =
   | _ -> failwith "not a constant"
 
 let get_const_from_qualid q =
-  match Smartlocate.global_with_alias q with
+  (* [~head:true] resolves abbreviations that expand to a (partially) applied
+     constant to the head constant (e.g. for [unfold:]). *)
+  match Smartlocate.global_with_alias ~head:true q with
   | Names.GlobRef.ConstRef(c) -> c
   | _ -> failwith "not a constant"
 

--- a/tests/tactics/tactics_test.v
+++ b/tests/tactics/tactics_test.v
@@ -1494,13 +1494,13 @@ Qed.
 Lemma lem_lelst_sorted {A} {dto : DecTotalOrder A} :
   forall l x, Sorted (x :: l) <-> LeLst x l /\ Sorted l.
 Proof.
-  induction l; sauto l: on use: lem_lelst_trans inv: Sorted, Forall ctrs: Sorted.
+  induction l; sauto l: on use: lem_lelst_trans inv: Sorted, List.Forall ctrs: Sorted.
 Qed.
 
 Lemma lem_lelst_perm_rev {A} {dto : DecTotalOrder A} :
   forall l1 l2, Permutation l1 l2 -> forall x, LeLst x l2 -> LeLst x l1.
 Proof.
-  induction 1; sauto inv: Forall ctrs: Forall.
+  induction 1; sauto inv: List.Forall ctrs: List.Forall.
 Qed.
 
 Lemma lem_lelst_app {A} {dto : DecTotalOrder A} :
@@ -1533,6 +1533,16 @@ Proof.
 Qed.
 
 Global Hint Resolve lem_lelst_nil lem_lelst_cons : lelst.
+
+(* Regression: inv:/ctrs: must accept a notation (abbreviation) for an
+   inductive type, including one that expands to a partial application. *)
+Notation ForallNat := (@List.Forall nat).
+
+Lemma lem_forall_abbrev (P : nat -> Prop) :
+  forall l x, ForallNat P (x :: l) -> ForallNat P l /\ P x.
+Proof.
+  sauto inv: ForallNat ctrs: ForallNat.
+Qed.
 
 Lemma lem_sorted_concat_2 {A} {dto : DecTotalOrder A} :
   forall (l l1 l2 : list A) x y,


### PR DESCRIPTION
## Problem

`sauto` option arguments such as `inv:`, `ctrs:`, `cases:`, `ssplit:` (and `unfold:`) failed when given a *notation* (syntactic abbreviation) for an inductive type that expands to a partial application. For example:

```coq
Notation ForallNat := (@List.Forall nat).
sauto inv: ForallNat ctrs: ForallNat.
(* Error: not an inductive type: ForallNat *)
```

The same class of failure showed up as `Error: not an inductive type: List.Forall` in some configurations.

## Root cause

Option arguments are resolved through `Hhutils.get_inductive_from_qualid` / `get_const_from_qualid`, which call `Smartlocate.global_with_alias`. That function defaults to `~head:false`, whose resolver only accepts an abbreviation whose body is a bare reference or a nullary application. An abbreviation that expands to a *partially applied* inductive (e.g. `Forall (A:=nat)`) is rejected with `Not_found`, surfacing as `not an inductive type: ...`.

## Fix

Pass `~head:true` to `Smartlocate.global_with_alias` in both resolvers. In head mode the resolver walks through `NApp`/`NCast`/`NLetIn` to the head reference, so a notation for an applied inductive/constant resolves to the underlying inductive/constant. The change is strictly more permissive — it only accepts cases that previously errored and never alters an existing resolution (a `TrueGlobal` ignores `head`).

## Tests

- Restored `List.Forall` (in place of the `Forall` workaround) in `lem_lelst_sorted` and `lem_lelst_perm_rev`.
- Added `lem_forall_abbrev` with `Notation ForallNat := (@List.Forall nat)` as a regression guard for the partial-application case.

The full `tests/tactics/tactics_test.v` suite compiles cleanly against the reinstalled tactics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `sauto` option arguments to accept notations that expand to partially applied inductives or constants. Fixes “not an inductive type” errors in inv:, ctrs:, cases:, ssplit:, and `unfold:`.

- **Bug Fixes**
  - Resolve abbreviations by calling `Smartlocate.global_with_alias ~head:true` in `get_inductive_from_qualid` and `get_const_from_qualid`.
  - Supports notations like `Notation ForallNat := (@List.Forall nat)` (e.g., `sauto inv: ForallNat`); added `lem_forall_abbrev` and restored `List.Forall` in tests.
  - Change is strictly more permissive; existing resolutions are unaffected.

<sup>Written for commit c4f5fe13cf84583b9f79e27c1ecb688620d18899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

