### PR TITLE
Fix issue #183: reconstruction tactics must solve or fail

### DIFF
--- a/src/tactics/g_hammer_tactics.mlg
+++ b/src/tactics/g_hammer_tactics.mlg
@@ -212,7 +212,7 @@ END
 
 TACTIC EXTEND Hammer_ssimpl
 | [ "ssimpl" sauto_opts(l) ] -> {
-  try_usolve (default_s_opts ()) l ssimpl "ssimpl failed"
+  try_usolve_partial (default_s_opts ()) l ssimpl "ssimpl failed"
 }
 END
 
@@ -221,19 +221,19 @@ TACTIC EXTEND Hammer_csimpl
   let opts =
     { (default_s_opts ()) with s_forwarding = false }
   in
-  try_usolve opts l ssimpl "csimpl failed"
+  try_usolve_partial opts l ssimpl "csimpl failed"
 }
 END
 
 TACTIC EXTEND Hammer_qsimpl
 | [ "qsimpl" sauto_opts(l) ] -> {
-  try_usolve (default_s_opts ()) l qsimpl "qsimpl failed"
+  try_usolve_partial (default_s_opts ()) l qsimpl "qsimpl failed"
 }
 END
 
 TACTIC EXTEND Hammer_sintuition
 | [ "sintuition" sauto_opts(l) ] -> {
-  try_usolve (default_s_opts ()) l sintuition "sintuition failed"
+  try_usolve_partial (default_s_opts ()) l sintuition "sintuition failed"
 }
 END
 

--- a/src/tactics/sauto.ml
+++ b/src/tactics/sauto.ml
@@ -1362,5 +1362,19 @@ let unshelve tac =
       Proofview.Unsafe.tclNEWGOALS (List.map Proofview.with_empty_state shelf)
     end
 
-let usolve tac =
+(* [usolve_partial] runs [tac], unshelves any goals it left on the shelf, and
+   tries to discharge them with [dsolve]. [dsolve] is best-effort (it never
+   fails), so this may leave subgoals behind. Used by the simplification
+   tactics (ssimpl, qsimpl, csimpl, sintuition), which are allowed to do so. *)
+let usolve_partial tac =
   unshelve tac <*> dsolve_tac ()
+
+(* [usolve] is like [usolve_partial] but additionally requires (via [tclSOLVE])
+   that no goal remains. This enforces the invariant that the reconstruction
+   tactics (sauto, hauto, qauto, scrush, ...) either solve the goal completely
+   or fail -- they must never leave subgoals behind (issue #183). A subgoal can
+   otherwise escape when the leaf tactic (e.g. [eauto]) "succeeds" by shelving
+   it: the shelved goal is not seen by the search's own [tclSOLVE], so it is
+   unshelved here and must then be discharged. *)
+let usolve tac =
+  Tacticals.tclSOLVE [ usolve_partial tac ]

--- a/src/tactics/sauto.mli
+++ b/src/tactics/sauto.mli
@@ -81,4 +81,5 @@ val add_inversion_hint : inductive -> unit
 val print_actions : s_opts -> unit Proofview.tactic
 
 val unshelve : 'a Proofview.tactic -> unit Proofview.tactic
+val usolve_partial : 'a Proofview.tactic -> unit Proofview.tactic
 val usolve : 'a Proofview.tactic -> unit Proofview.tactic

--- a/src/tactics/tactics_main.ml
+++ b/src/tactics/tactics_main.ml
@@ -7,16 +7,24 @@ open Tacopts
 
 module Utils = Hhutils
 
-let try_usolve (opts : s_opts) (lst : sopt_t list) (ret : s_opts -> unit Proofview.tactic)
+let try_usolve_with (finish : unit Proofview.tactic -> unit Proofview.tactic)
+      (opts : s_opts) (lst : sopt_t list) (ret : s_opts -> unit Proofview.tactic)
       (msg : string) : unit Proofview.tactic =
   try_tactic begin fun () ->
-    usolve @@
+    finish @@
       interp_opts opts lst
         begin fun opts ->
           Proofview.tclORELSE (ret opts)
             (fun _ -> Tacticals.tclZEROMSG (Pp.str msg))
         end
   end
+
+(* For the reconstruction tactics, which must either solve the goal or fail. *)
+let try_usolve = try_usolve_with usolve
+
+(* For the simplification tactics (ssimpl, qsimpl, csimpl, sintuition), which
+   are allowed to leave subgoals behind. *)
+let try_usolve_partial = try_usolve_with usolve_partial
 
 let with_delayed_uconstr ist c tac =
   let flags = Pretyping.default_inference_flags false in

--- a/tests/tactics/tactics_test.v
+++ b/tests/tactics/tactics_test.v
@@ -1660,3 +1660,22 @@ Next Obligation.
 Defined.
 
 End MergeSort.
+
+(* Issue #183: the reconstruction tactics must either solve the goal
+   completely or fail -- they should never leave subgoals behind, even
+   when a leaf tactic "succeeds" by shelving an unprovable goal. *)
+
+Lemma lem_issue_183_1 : (forall P : Prop, P) /\ True.
+Proof.
+  Fail srun ltac:(split; [ shelve | exact I ]).
+  Fail qauto.
+  Fail hauto.
+  Fail sauto.
+  Fail scrush.
+Abort.
+
+Lemma lem_issue_183_2 : 1 = 1 /\ 2 = 2.
+Proof.
+  (* a genuinely solvable goal is still solved *)
+  qauto.
+Qed.


### PR DESCRIPTION
Fixes #183.

## Problem

The reconstruction tactics (`sauto`, `hauto`, `qauto`, `scrush`, ...) could leave subgoals behind instead of either solving the goal completely or failing, as reported in #183.

The cause is in `usolve` (the wrapper all reconstruction tactics run through). A leaf tactic (e.g. `eauto` for `qauto`) can "succeed" by *shelving* a subgoal it cannot close. The search's own `tclSOLVE` only checks *focused* goals, so the shelved goal escapes and the search reports success. `usolve` then unshelves those goals and runs `dsolve` on them — but `dsolve` (`auto with shints; try seasy; try solve [ do 10 constructor ]`) is best-effort and never fails, so anything it cannot close is simply left behind while the tactic reports success.

## Fix

`usolve` now requires, via `tclSOLVE`, that no goal remains after unshelving and `dsolve`, so a reconstruction tactic that cannot fully close the goal now fails instead of leaving subgoals.

The non-completing wrapper (`unshelve tac <*> dsolve_tac ()`) is kept as `usolve_partial` and used by the simplification tactics `ssimpl`, `qsimpl`, `csimpl`, `sintuition`, which are *allowed* to leave goals (via the new `try_usolve_partial`).

## Testing

- Added a regression test in `tests/tactics/tactics_test.v` covering the shelving pathology.
- Full tactics suite (`tactics_test.v`, `legacy_tactics_test.v`) passes.
- Verified directly: a leaf tactic that shelves an unsolved goal now makes the reconstruction tactic fail rather than leave the goal; genuinely solvable goals are still solved; the simplification tactics still leave goals as intended.

Note: the exact `FMap`-based failure from the original report could not be reproduced on Rocq 9.1 (those goals get fully solved here, consistent with the observation that Coq-version shelving changes are involved), so the fix was validated against the underlying mechanism. It is version-agnostic: whatever shelves a goal, `usolve` now surfaces it and fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make reconstruction tactics (sauto, hauto, qauto, scrush, …) always solve the goal or fail. Fixes #183 by preventing shelved subgoals from escaping.

- **Bug Fixes**
  - `usolve` now enforces completion with `tclSOLVE` after `unshelve` and `dsolve`, so any leftover goals cause failure.
  - Added `usolve_partial` (old behavior) for `ssimpl`, `qsimpl`, `csimpl`, `sintuition`, wired via `try_usolve_partial`.
  - Added regression tests to ensure reconstruction tactics fail on unsolved shelves and still solve genuinely solvable goals.

<sup>Written for commit 7334b94adda4869d7f895b477b596964878c2f40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

