### PR TITLE
Fix issue #86: Not_found with parallel proof processing in an IDE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Overview of changes
 * Fixed translation regression due to changed qualified Rocq names for logical connectives.
 * Fixed `dune` build.
 * Fixed deprecation warnings.
-* Fixed issues #118, #119, #130, #134, #138, #140, #144, #183, #202.
+* Fixed issues #86, #118, #119, #130, #134, #138, #140, #144, #183, #202.
 
 CoqHammer v. 1.3.2
 ==================

--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -130,9 +130,16 @@ let get_type_of env evmap t =
 
 (* only for constants *)
 let hhproof_of c =
+  (* [body_of_constant] may raise [Not_found] when the opaque proof body
+     is not accessible in the current process. This happens with parallel
+     proof processing in an IDE (e.g. CoqIDE), where opaque proofs are
+     delegated to worker processes and their opaque tables are not loaded
+     here (issue #86). A constant whose body cannot be accessed is treated
+     as an axiom. *)
   begin match Global.body_of_constant Library.indirect_accessor c with
   | Some (b, _, _) -> hhterm_of b
   | None -> mk_id "$Axiom"
+  | exception Not_found -> mk_id "$Axiom"
   end
 
 let hhdef_of_global env sigma glob_ref : (string * Hh_term.hhdef) =

--- a/src/tactics/sauto.ml
+++ b/src/tactics/sauto.ml
@@ -421,8 +421,13 @@ let get_consts evd lst =
           end
           lst))
 
+(* [body_of_constant] may raise [Not_found] when the opaque proof body is
+   not accessible in the current process, e.g. with parallel proof
+   processing in an IDE (issue #86, #64). Such a constant is treated as
+   not unfoldable. *)
 let is_simple_unfold b_aggressive c =
   match Global.body_of_constant Library.indirect_accessor c with
+  | exception Not_found -> false
   | Some (b, _, _) ->
      begin
        let t = EConstr.of_constr b in
@@ -439,6 +444,7 @@ let is_simple_unfold b_aggressive c =
 (* -1 if not a case unfold *)
 let case_unfold_cost c =
   match Global.body_of_constant Library.indirect_accessor c with
+  | exception Not_found -> -1
   | Some (b, _, _) ->
      begin
        let t = EConstr.of_constr b in


### PR DESCRIPTION
Fixes #86.

## Problem

Running `hammer` while compiling a whole file with parallel proof processing in CoqIDE (`-async-proofs on`) fails with:

```
CoqHammer bug: please report: Not_found
```

## Root cause

During premise selection, `hammer` builds a dependency graph over all accessible lemmas (`Features.get_deps`), which forces the **opaque proof body** of every def via `hhproof_of` → `Global.body_of_constant`. For an opaque constant this reads Rocq's opaque-proof table. With async proof processing, opaque proofs are delegated to worker processes and their opaque tables are not loaded in the current process, so the table lookup raises a bare `Not_found`, which surfaces as the "bug" message.

(Note `get_def_fea_term`, used for features, already skips opaque bodies; only `get_deps` forces them.)

## Fix

- `hhproof_of` (`hammer_main.ml`): treat a constant whose body cannot be accessed (`Not_found`) as an axiom, exactly as the existing `None` case does. Full behavior is preserved in normal mode; async mode degrades gracefully.
- `sauto.ml`: harden the two analogous `body_of_constant` call sites (`is_simple_unfold`, `case_unfold_cost`) so reconstruction is robust against the same situation — the `sauto` variant noted in #64. (`hhlpo.ml` already guards with `is_opaque` and is safe.)

## Verification

- Reproduced the exact issue example under `coqc -async-proofs on`: `Not_found` before, gone after.
- After the fix, async mode reaches the ATP stage identically to synchronous mode.
- `make quicktest` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Not_found crash when running `hammer` with parallel proof processing (`-async-proofs on`) in CoqIDE by handling inaccessible opaque proof bodies gracefully. `hammer` and `sauto` now fall back instead of forcing those bodies.

- **Bug Fixes**
  - In `hammer_main.ml`, `hhproof_of` treats `Global.body_of_constant` raising `Not_found` as an axiom (same as `None`), preventing crashes during premise selection.
  - In `sauto.ml`, `is_simple_unfold` and `case_unfold_cost` catch `Not_found` and treat the constant as non-unfoldable, making reconstruction robust in async mode.

<sup>Written for commit 3d7c96792cd273a8a8fff80d831c52ad3f3d4c35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

