### PR TITLE
Support SProp in the translation; regression tests for issue #156

### DIFF
--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -34,6 +34,10 @@ let hhterm_of_global glob =
   mk_id (Libnames.string_of_path (Nametab.path_of_global (Globnames.canonical_gr glob)))
 
 let hhterm_of_sort s = match s with
+  (* SProp is intentionally collapsed to Prop: like Prop it is
+     proof-irrelevant, so in the FOL translation its inhabitants become the
+     opaque $Proof constant and its types become formulas, exactly as for Prop.
+     See issue #141. *)
   | SProp -> mk_id "$Prop"
   | Prop -> mk_id "$Prop"
   | Set  -> mk_id "$Set"
@@ -385,7 +389,7 @@ let check_goal_prop gl =
     EConstr.to_constr evmap (Retyping.get_type_of env evmap (Proofview.Goal.concl gl))
   in
   match Constr.kind tp with
-  | Sort s -> Sorts.is_prop s
+  | Sort s -> Sorts.is_prop s || Sorts.is_sprop s
   | _ -> false
 
 (***************************************************************************************)

--- a/tests/plugin/plugin_test.v
+++ b/tests/plugin/plugin_test.v
@@ -23,3 +23,31 @@ Proof.
   predict 16.
   hammer.
 Qed.
+
+(* Issue #156 / #141: SProp support, end-to-end via hammer. *)
+
+From Stdlib Require Import StrictProp.
+
+Fixpoint s_eq_nat (n m : nat) : SProp :=
+  match n with
+  | O => match m with O => sUnit | _ => sEmpty end
+  | S n' => match m with O => sEmpty | S m' => s_eq_nat n' m' end
+  end.
+
+(* An SProp goal is proved and reconstructed. *)
+Goal sUnit.
+Proof. hammer. Qed.
+
+(* An SProp goal with an SProp hypothesis: translation + reconstruction. *)
+Lemma lem_sprop_id : forall n m, s_eq_nat n m -> s_eq_nat n m.
+Proof. hammer. Qed.
+
+(* The original #156 example. On old Rocq this raised a kernel anomaly
+   ("kernel/inductive.ml ... Assertion failed"). It is fixed upstream on Rocq
+   9.1; hammer now fails gracefully -- the ATPs cannot prove it because the
+   SProp-recursive s_eq_nat is translated proof-irrelevantly (its computational
+   content is lost), which is a completeness limitation, not a crash. We only
+   assert the absence of an anomaly: a real kernel anomaly is a critical
+   exception that "try" cannot swallow, so it would fail this file. *)
+Goal forall n m, s_eq_nat n m -> n = m.
+Proof. intros n m. try hammer. Abort.

--- a/tests/tactics/tactics_test.v
+++ b/tests/tactics/tactics_test.v
@@ -1771,3 +1771,40 @@ Proof.
 Qed.
 
 End SetoidRewriting.
+
+(* Issue #156 / #141: SProp support in reconstruction. These are ATP-free
+   regressions locking in that sauto handles SProp goals and hypotheses like
+   Prop, and -- crucially -- declines an illegal elimination of a non-empty
+   SProp hypothesis into a non-SProp goal by failing cleanly, without ever
+   raising a kernel anomaly (the #156 symptom). *)
+
+From Stdlib Require Import StrictProp.
+
+Section SPropTests.
+
+Fixpoint s_eq_nat (n m : nat) : SProp :=
+  match n with
+  | O => match m with O => sUnit | _ => sEmpty end
+  | S n' => match m with O => sEmpty | S m' => s_eq_nat n' m' end
+  end.
+
+(* An SProp goal is provable, just like a Prop goal. *)
+Goal sUnit.
+Proof. sauto. Qed.
+
+(* An SProp goal established by induction. *)
+Lemma lem_sprop_refl : forall n, s_eq_nat n n.
+Proof. induction n; sauto. Qed.
+
+(* Eliminating an *empty* SProp hypothesis into a Prop goal is legal in CIC
+   and sauto performs it. *)
+Lemma lem_sprop_empty_elim : forall n, s_eq_nat (S n) 0 -> False.
+Proof. sauto. Qed.
+
+(* Eliminating a *non-empty* SProp hypothesis into a non-SProp (Prop) goal is
+   illegal in CIC. sauto must fail cleanly ("No applicable tactic") -- it must
+   never raise a kernel anomaly (issue #156). *)
+Lemma lem_sprop_illegal_elim : forall n m, s_eq_nat n m -> n = m.
+Proof. Fail sauto. Abort.
+
+End SPropTests.


### PR DESCRIPTION
## Summary

Adds proper handling of Coq's `SProp` (definitionally proof-irrelevant strict propositions) to the CoqHammer translation, treating it analogously to `Prop`, and locks in the behaviour with regression tests for issue #156.

In the FOL translation SProp is collapsed to the `$Prop` marker at the single point where sorts are observed (`hhterm_of_sort`), so its inhabitants become the opaque `$Proof` constant and its types become formulas — exactly the Prop path. This was already true; the remaining gap was `check_goal_prop`, which used the kernel `Sorts.is_prop` (false for SProp) directly.

## Changes

- **`src/plugin/hammer_main.ml`**
  - `check_goal_prop`: accept `Sorts.is_sprop` alongside `Sorts.is_prop`, so an SProp *goal* is recognised as propositional. (Consumed by the eval/benchmark `Hammer_hook` path; the interactive `hammer` tactic already accepted SProp goals.)
  - `hhterm_of_sort`: comment documenting the intentional `SProp -> $Prop` collapse.
- **`tests/tactics/tactics_test.v`** (ATP-free `sauto` regressions): SProp goal proved by `sauto`; SProp goal by induction; empty-SProp elimination into a Prop goal (legal); and the illegal elimination of a *non-empty* SProp hypothesis into a Prop goal, which `sauto` must decline cleanly — never a kernel anomaly (the #156 symptom).
- **`tests/plugin/plugin_test.v`** (end-to-end `hammer`): SProp goals proved and reconstructed; plus the original #156 example guarded with `try hammer` to assert the absence of the kernel anomaly.

## Notes on #156

The `kernel/inductive.ml` assertion from #156 is **no longer reproducible on Rocq 9.1.1** — it was fixed upstream, and Rocq's own `inversion`/`destruct`/kernel now guard illegal SProp eliminations. The ATPs' inability to prove `s_eq_nat n m -> n = m` is a *completeness* limitation of encoding SProp proof-irrelevantly (its computational content is lost), not a crash. These tests lock in the now-correct behaviour.

## Testing

- `make quicktest` passes (exit 0), no errors or anomalies.

Refs #156, #141.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `SProp` like `Prop` in CoqHammer’s translation and goal detection, and adds regressions for #156 to ensure illegal SProp eliminations fail cleanly. Aligns with #141 by making `hammer`/`sauto` handle `SProp` goals consistently on Rocq 9.1.

- **Bug Fixes**
  - `check_goal_prop`: accept `Sorts.is_sprop` alongside `Sorts.is_prop` so `Hammer_hook` recognizes `SProp` goals as propositional.
  - Documented the intentional `SProp -> $Prop` collapse in `hhterm_of_sort`.
  - Regression tests:
    - `sauto`: proves `SProp` goals, allows empty-`SProp` elimination into `Prop`, and cleanly rejects non-empty `SProp` elimination (no kernel anomaly).
    - `hammer`: proves and reconstructs `SProp` goals; original #156 guarded with `try hammer` to assert no anomaly.

<sup>Written for commit 01d7c710992510a29905168ef2850ae60d833c24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

