### PR TITLE
Fix issue #180: use Unix._exit in forked children to avoid IDE desync

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Overview of changes
 * Fixed translation regression due to changed qualified Rocq names for logical connectives.
 * Fixed `dune` build.
 * Fixed deprecation warnings.
-* Fixed issues #86, #118, #119, #130, #134, #138, #140, #144, #183, #202.
+* Fixed issues #86, #118, #119, #130, #134, #138, #140, #144, #180, #183, #202.
 
 CoqHammer v. 1.3.2
 ==================

--- a/src/lib/hhpartac.ml
+++ b/src/lib/hhpartac.ml
@@ -12,7 +12,7 @@ let partac time lst0 cont =
                Unix.sleep time;
                List.iter (fun i -> try Unix.kill i Sys.sigterm with _ -> ()) pids
              end;
-           exit 0
+           Unix._exit 0
          end
        else
          let clean () =
@@ -52,8 +52,8 @@ let partac time lst0 cont =
        if pid = 0 then
          begin (* a worker *)
            Proofview.tclOR
-             (Proofview.tclBIND tac (fun _ -> exit 0))
-             (fun _ -> exit 1)
+             (Proofview.tclBIND tac (fun _ -> Unix._exit 0))
+             (fun _ -> Unix._exit 1)
          end
        else
          pom t (pid :: pids)

--- a/src/plugin/hammer_main.ml
+++ b/src/plugin/hammer_main.ml
@@ -715,7 +715,7 @@ let run_gs_provers hyps deps goal clean seq =
     List.map
       begin fun (pname, enabled, pref, select) _ ->
         if not enabled then
-          exit 1;
+          Unix._exit 1;
         Opt.vampire_enabled := false;
         Opt.eprover_enabled := false;
         Opt.z3_enabled := false;
@@ -732,9 +732,9 @@ let run_gs_provers hyps deps goal clean seq =
         with
         | HammerError(msg) ->
            Msg.error ("Hammer error: " ^ msg);
-           exit 1
+           Unix._exit 1
         | _ ->
-           exit 1
+           Unix._exit 1
       end
       (Hhlib.take !Opt.gs_mode (List.filter (fun (_, enabled, _, _) -> enabled) seq))
   in
@@ -1113,19 +1113,19 @@ let hammer_hook_tac prefix name =
                                      let msg = "Success " ^ name ^ " " ^ str ^ " " ^ tac in
                                      ignore (Sys.command ("echo \"" ^ msg ^ "\" > \"" ^ ofname ^ "\""));
                                      Msg.info msg;
-                                     exit 0
+                                     Unix._exit 0
                                    end
                                    begin fun () ->
                                      let msg = "Failure " ^ name ^ " " ^ str in
                                      ignore (Sys.command ("echo \"" ^ msg ^ "\" > \"" ^ ofname ^ "\""));
                                      Msg.info msg;
-                                     exit 1
+                                     Unix._exit 1
                                    end
                                    (fun _ -> ())
                                end
-                               (fun p -> Feedback.msg_notice p; exit 1)
+                               (fun p -> Feedback.msg_notice p; Unix._exit 1)
                            with _ ->
-                             exit 1
+                             Unix._exit 1
                          end
                        else
                          begin
@@ -1160,17 +1160,17 @@ let hammer_hook_tac prefix name =
                                let msg = "Success " ^ name in
                                ignore (Sys.command ("echo \"" ^ msg ^ "\" > \"" ^ ofname ^ "\""));
                                Msg.info msg;
-                               exit 0))
+                               Unix._exit 0))
                           begin fun _ ->
                             let msg = "Failure " ^ name in
                             ignore (Sys.command ("echo \"" ^ msg ^ "\" > \"" ^ ofname ^ "\""));
                             Msg.info msg;
-                            exit 1
+                            Unix._exit 1
                           end
                       end
-                      (fun p -> Feedback.msg_notice p; exit 1)
+                      (fun p -> Feedback.msg_notice p; Unix._exit 1)
                   with _ ->
-                    exit 1
+                    Unix._exit 1
                 else
                   begin
                     ignore (Unix.waitpid [] pid);

--- a/src/plugin/parallel.ml
+++ b/src/plugin/parallel.ml
@@ -18,10 +18,10 @@ let run_parallel (progress_fn : 'a -> unit) (sec_fn : unit -> unit)
           let ret = f progress_sub_fn in
           output_value oc (Inr ret);
           flush oc;
-          exit 0
+          Unix._exit 0
         with _ ->
-          try output_value oc (Err (Unix.getpid ())); flush oc; exit 0
-          with _ -> exit 0
+          try output_value oc (Err (Unix.getpid ())); flush oc; Unix._exit 0
+          with _ -> Unix._exit 0
       end;
     pid
   in

--- a/src/plugin/provers.ml
+++ b/src/plugin/provers.ml
@@ -376,7 +376,7 @@ let call_provers_par fname ofname =
   let jobs =
     List.map
       begin fun ((_, pname, _, _) as h) _ ->
-        call_prover h fname (ofname ^ "." ^ pname) (fun () -> exit 1)
+        call_prover h fname (ofname ^ "." ^ pname) (fun () -> Unix._exit 1)
       end
       provers
   in
@@ -427,17 +427,17 @@ let minimize info hyps deps goal =
           if pname <> pname1 then
             begin
               let (pname2, info2) =
-                call_prover h fname (ofname ^ "." ^ pname) (fun () -> exit 1)
+                call_prover h fname (ofname ^ "." ^ pname) (fun () -> Unix._exit 1)
               in
               if List.length info2.deps < List.length info.deps ||
                 List.length info2.defs < List.length info.defs
               then
                 (pname2, info2)
               else
-                exit 1
+                Unix._exit 1
             end
           else
-            exit 1
+            Unix._exit 1
         end
         provers
     in

--- a/src/plugin/timeout.ml
+++ b/src/plugin/timeout.ml
@@ -15,8 +15,8 @@ let ptimeout n tac =
   if pid = 0 then
     begin (* the worker *)
       Proofview.tclOR
-        (Proofview.tclBIND tac (fun _ -> exit 0))
-        (fun _ -> exit 1)
+        (Proofview.tclBIND tac (fun _ -> Unix._exit 0))
+        (fun _ -> Unix._exit 1)
     end
   else
     begin
@@ -25,7 +25,7 @@ let ptimeout n tac =
         begin (* the watchdog *)
           Unix.sleep n;
           Unix.kill pid Sys.sigterm;
-          exit 0
+          Unix._exit 0
         end;
       let clean () =
         ignore (try Unix.kill pid2 Sys.sigterm with _ -> ())


### PR DESCRIPTION
## Problem

Fixes #180.

Aborting (or even just running) `best`/`sauto` variants in an IDE such as Proof General can leave the UI and the kernel out of sync — e.g. Coq reports `nth_ok already exists` for a definition the IDE believes was retracted. It is nondeterministic.

## Root cause

The parallel tactic/prover machinery forks worker and watchdog processes (`Hhpartac.partac` for `best`/`hbest`/`sbest`, `Timeout.ptimeout`, `Parallel.run_parallel`, and the ATP/eval forks in `provers.ml`/`hammer_main.ml`). Each forked child terminates with OCaml's `Stdlib.exit`.

`Stdlib.exit` runs `at_exit` handlers, which **flush every buffered `out_channel`** — including `stdout`. Under `coqidetop`, `stdout` is the XML-protocol channel to the IDE, and the fork inherits that file descriptor along with whatever the parent had buffered but not yet sent. When the worker exits it flushes those pending bytes into the protocol stream, injecting duplicate/garbage data and desynchronizing the UI from the kernel. It is nondeterministic because it depends on what is buffered at fork time; interrupting makes it more likely, since the catch-all worker handler swallows `Sys.Break` and then exits, flushing again.

## Fix

Use `Unix._exit` in every forked child. `Unix._exit` performs an immediate `_exit(2)` with no buffer flush and no `at_exit` handlers, so it cannot corrupt channels shared with the parent. In `parallel.ml` the children still explicitly `flush oc` their own result channel first, so their intended output is preserved.

The standalone C/C++ binaries (`predict`, `htimeout`) are separate process mains, not forked children, and are left unchanged.

## Verification

- `just check` passes (`make install` + `make quicktest`; `plugin_test.vo` and `tactics_test.vo` both compile).
- `best` still solves goals correctly through the forked `partac` path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch forked workers and watchdogs to `Unix._exit` to avoid flushing inherited stdout and corrupting the `coqidetop` protocol, preventing IDE/kernel desync when running or aborting `best`/`sauto`. Fixes #180.

- **Bug Fixes**
  - Replaced `Stdlib.exit` with `Unix._exit` in forked children across parallel tactic/prover code (`hhpartac.ml`, `timeout.ml`, `parallel.ml`, `hammer_main.ml`, `provers.ml`).
  - In `parallel.ml`, explicitly `flush` the child result channel before `Unix._exit` to keep intended output.
  - Updated `CHANGES.md` to include issue #180.

<sup>Written for commit 99472f655b20dda0848d1da3cd844a8411e15249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

