### PR TITLE
Fix issue #180 on the interrupt path: forked children must not escape into the toplevel

### DIFF
--- a/src/lib/hhpartac.ml
+++ b/src/lib/hhpartac.ml
@@ -1,5 +1,36 @@
 (* Parallel invocation of tactics *)
 
+(* Forked children must never touch the toplevel's standard descriptors:
+   under an IDE (coqtop -emacs, coqidetop) stdin/stdout carry the prover
+   protocol, and a child that escapes into the read-eval-print loop starts
+   competing with the parent for those channels, desynchronizing the UI
+   from the kernel (issue #180).  This can actually happen: on Ctrl-C the
+   toplevel's [Sys.catch_break] handler raises [Sys.Break] in every
+   process of the terminal's foreground group, including our forks, and
+   [Proofview.tclOR] does not catch critical exceptions, so a worker
+   unwinds past [Unix._exit] into [Coqloop].  Detaching the descriptors
+   makes any such escape harmless (the REPL reads EOF and exits), and
+   restoring the default SIGINT behaviour makes Ctrl-C simply kill the
+   child. *)
+let detach_child () =
+  Sys.set_signal Sys.sigint Sys.Signal_default;
+  (* A child that still escapes past [Unix._exit] (a critical exception
+     unwinding into the toplevel loop, which then reads EOF from
+     /dev/null and exits normally) must report failure, not success:
+     legitimate terminations use [Unix._exit], which bypasses
+     [at_exit].  Exiting immediately here also prevents flushing of
+     inherited channel buffers (the concern of PR #229) on any
+     remaining [Stdlib.exit] path. *)
+  at_exit (fun () -> Unix._exit 2);
+  (* An exception must never escape from a freshly forked child. *)
+  try
+    let devnull = Unix.openfile "/dev/null" [Unix.O_RDWR] 0o600 in
+    Unix.dup2 devnull Unix.stdin;
+    Unix.dup2 devnull Unix.stdout;
+    Unix.dup2 devnull Unix.stderr;
+    Unix.close devnull
+  with _ -> ()
+
 let partac time lst0 cont =
   let rec pom lst pids =
     match lst with
@@ -7,18 +38,36 @@ let partac time lst0 cont =
        let pid2 = Unix.fork () in
        if pid2 = 0 then
          begin (* the watchdog *)
-           if time > 0 then
-             begin
-               Unix.sleep time;
-               List.iter (fun i -> try Unix.kill i Sys.sigterm with _ -> ()) pids
-             end;
+           detach_child ();
+           begin
+             try
+               if time > 0 then
+                 begin
+                   Unix.sleep time;
+                   List.iter (fun i -> try Unix.kill i Sys.sigterm with _ -> ()) pids
+                 end
+             with _ -> ()
+           end;
            Unix._exit 0
          end
        else
+         let cleaned = ref false in
          let clean () =
-           List.iter (fun i -> try Unix.kill i Sys.sigterm with _ -> ()) pids;
-           ignore (try Unix.kill pid2 Sys.sigterm with _ -> ());
-           List.iter (fun i -> try ignore (Unix.waitpid [] i) with _ -> ()) pids
+           (* Idempotent: [clean] may be reached again when an exception
+              is raised from [cont] after a normal cleanup; the pids may
+              have been reaped and recycled by then, so they must not be
+              killed twice. *)
+           if not !cleaned then
+             begin
+               cleaned := true;
+               (* Kill and reap the watchdog first: while it lives it
+                  may SIGTERM a worker pid, which must not happen after
+                  that pid has been reaped (and possibly recycled). *)
+               ignore (try Unix.kill pid2 Sys.sigterm with _ -> ());
+               (try ignore (Unix.waitpid [] pid2) with _ -> ());
+               List.iter (fun i -> try Unix.kill i Sys.sigterm with _ -> ()) pids;
+               List.iter (fun i -> try ignore (Unix.waitpid [] i) with _ -> ()) pids
+             end
          in
          let n = List.length lst0 in
          let rec wait k =
@@ -29,7 +78,22 @@ let partac time lst0 cont =
                end
            else
              let (pid, status) = Unix.wait () in
-             if pid = pid2 && time > 0 then
+             let interrupted =
+               (* The children have the default SIGINT behaviour, so a
+                  child killed by SIGINT means Ctrl-C: propagate the
+                  interrupt instead of racing with the parent's own
+                  pending [Sys.Break] (losing that race would turn the
+                  user's interrupt into a mere tactic failure). *)
+               match status with
+               | Unix.WSIGNALED s -> s = Sys.sigint
+               | _ -> false
+             in
+             if interrupted then
+               begin
+                 clean ();
+                 raise Sys.Break
+               end
+             else if pid = pid2 && time > 0 then
                begin
                  clean ();
                  cont (-1) (Proofview.tclZERO Logic_monad.Tac_Timeout)
@@ -46,11 +110,19 @@ let partac time lst0 cont =
              else
                wait k
          in
-         wait n
+         (* [Unix.wait] is interrupted by Ctrl-C ([Sys.Break]); the
+            children must be killed and reaped before the interrupt
+            propagates, or they are leaked. *)
+         (try wait n
+          with e ->
+            let e = Exninfo.capture e in
+            clean ();
+            Exninfo.iraise e)
     | tac :: t ->
        let pid = Unix.fork () in
        if pid = 0 then
          begin (* a worker *)
+           detach_child ();
            Proofview.tclOR
              (Proofview.tclBIND tac (fun _ -> Unix._exit 0))
              (fun _ -> Unix._exit 1)

--- a/src/lib/hhpartac.ml
+++ b/src/lib/hhpartac.ml
@@ -50,7 +50,7 @@ let worker time tac =
   if time > 0 then
     begin
       Sys.set_signal Sys.sigalrm Sys.Signal_default;
-ignore (Unix.alarm (min time (Sys.max_int - 5) + 5))
+      ignore (Unix.alarm (min time (Sys.max_int - 5) + 5))
     end;
   Proofview.tclOR
     (Proofview.tclBIND tac (fun _ -> Unix._exit 0))

--- a/src/lib/hhpartac.ml
+++ b/src/lib/hhpartac.ml
@@ -50,7 +50,7 @@ let worker time tac =
   if time > 0 then
     begin
       Sys.set_signal Sys.sigalrm Sys.Signal_default;
-      ignore (Unix.alarm (time + 5))
+ignore (Unix.alarm (min time (Sys.max_int - 5) + 5))
     end;
   Proofview.tclOR
     (Proofview.tclBIND tac (fun _ -> Unix._exit 0))

--- a/src/lib/hhpartac.ml
+++ b/src/lib/hhpartac.ml
@@ -31,8 +31,30 @@ let detach_child () =
     Unix.dup2 devnull Unix.stdin;
     Unix.dup2 devnull Unix.stdout;
     Unix.dup2 devnull Unix.stderr;
-    Unix.close devnull
+    (* [openfile] returns the lowest free descriptor: if a standard
+       descriptor was closed at fork time, [devnull] IS that
+       descriptor, and closing it would undo its own redirection. *)
+    if devnull <> Unix.stdin && devnull <> Unix.stdout && devnull <> Unix.stderr
+    then Unix.close devnull
   with _ -> Unix._exit 2
+
+(* The body of a forked worker: detach from the toplevel, run the
+   tactic, and report success or failure through the exit status.
+   When [time > 0] the worker also arms a SIGALRM deadline slightly
+   beyond the timeout: the parent normally kills it earlier, so the
+   alarm only bounds the lifetime of a worker orphaned by a parent
+   that died without cleaning up -- and a worker signalling itself
+   cannot hit a recycled pid. *)
+let worker time tac =
+  detach_child ();
+  if time > 0 then
+    begin
+      Sys.set_signal Sys.sigalrm Sys.Signal_default;
+      ignore (Unix.alarm (time + 5))
+    end;
+  Proofview.tclOR
+    (Proofview.tclBIND tac (fun _ -> Unix._exit 0))
+    (fun _ -> Unix._exit 1)
 
 (* Restart [f x] when interrupted by a signal whose OCaml handler
    returns normally: the kernel then fails the underlying system call
@@ -76,17 +98,16 @@ let partac time lst0 cont =
     | [] ->
        let pid2 = Unix.fork () in
        if pid2 = 0 then
-         begin (* the watchdog *)
+         begin (* The watchdog: a pure timer.  It must not signal the
+                  worker pids itself: it only holds a fork-time
+                  snapshot of them, and by the time it fires some may
+                  have been reaped by the parent -- and recycled by
+                  the kernel, so the signal could hit an unrelated
+                  process.  The parent, which knows which pids are
+                  still live, does the killing when [Unix.wait]
+                  returns the watchdog. *)
            detach_child ();
-           begin
-             try
-               if time > 0 then
-                 begin
-                   Unix.sleep time;
-                   List.iter (fun i -> try Unix.kill i Sys.sigterm with _ -> ()) pids
-                 end
-             with _ -> ()
-           end;
+           (try if time > 0 then Unix.sleep time with _ -> ());
            Unix._exit 0
          end
        else
@@ -141,12 +162,7 @@ let partac time lst0 cont =
     | tac :: t ->
        let pid = Unix.fork () in
        if pid = 0 then
-         begin (* a worker *)
-           detach_child ();
-           Proofview.tclOR
-             (Proofview.tclBIND tac (fun _ -> Unix._exit 0))
-             (fun _ -> Unix._exit 1)
-         end
+         worker time tac
        else
          pom t (pid :: pids)
   in

--- a/src/lib/hhpartac.ml
+++ b/src/lib/hhpartac.ml
@@ -22,14 +22,53 @@ let detach_child () =
      inherited channel buffers (the concern of PR #229) on any
      remaining [Stdlib.exit] path. *)
   at_exit (fun () -> Unix._exit 2);
-  (* An exception must never escape from a freshly forked child. *)
+  (* An exception must never escape from a freshly forked child; and a
+     child whose descriptors could not be detached would keep the
+     toplevel's protocol channels, recreating the hazard above, so
+     abort it outright (its exit status reports a failed tactic). *)
   try
     let devnull = Unix.openfile "/dev/null" [Unix.O_RDWR] 0o600 in
     Unix.dup2 devnull Unix.stdin;
     Unix.dup2 devnull Unix.stdout;
     Unix.dup2 devnull Unix.stderr;
     Unix.close devnull
-  with _ -> ()
+  with _ -> Unix._exit 2
+
+(* Restart [f x] when interrupted by a signal whose OCaml handler
+   returns normally: the kernel then fails the underlying system call
+   with EINTR, which must not be confused with a real error (or,
+   worse, a timeout).  A handler that raises instead -- as
+   [Sys.catch_break]'s does with [Sys.Break] on Ctrl-C -- propagates
+   out of [f] as usual. *)
+let rec restart_on_eintr f x =
+  try f x with Unix.Unix_error (Unix.EINTR, _, _) -> restart_on_eintr f x
+
+let killed_by_sigint status =
+  match status with
+  | Unix.WSIGNALED s -> s = Sys.sigint
+  | _ -> false
+
+(* SIGTERM and reap the child processes still listed in [live],
+   removing each pid as it is reaped.  A pid leaves [live] only when
+   reaped, and only reaped pids can be recycled by the kernel, so no
+   signal is ever sent to a pid that may denote an unrelated process.
+   This also makes the cleanup idempotent and re-entrant: if it is
+   itself interrupted -- an asynchronous [Sys.Break] arriving during
+   [kill] or [waitpid] must propagate rather than be swallowed
+   together with the user's interrupt -- running it again finishes the
+   job.  Watchdog processes must precede workers in [live]: a watchdog
+   is then reaped -- hence provably no longer signalling anybody --
+   before the worker pids it holds are reaped and become recyclable. *)
+let kill_children live =
+  List.iter
+    (fun pid -> try Unix.kill pid Sys.sigterm with Unix.Unix_error _ -> ())
+    !live;
+  List.iter
+    (fun pid ->
+      (try ignore (restart_on_eintr (Unix.waitpid []) pid)
+       with Unix.Unix_error (Unix.ECHILD, _, _) -> ());
+      live := List.filter (fun p -> p <> pid) !live)
+    !live
 
 let partac time lst0 cont =
   let rec pom lst pids =
@@ -51,24 +90,9 @@ let partac time lst0 cont =
            Unix._exit 0
          end
        else
-         let cleaned = ref false in
-         let clean () =
-           (* Idempotent: [clean] may be reached again when an exception
-              is raised from [cont] after a normal cleanup; the pids may
-              have been reaped and recycled by then, so they must not be
-              killed twice. *)
-           if not !cleaned then
-             begin
-               cleaned := true;
-               (* Kill and reap the watchdog first: while it lives it
-                  may SIGTERM a worker pid, which must not happen after
-                  that pid has been reaped (and possibly recycled). *)
-               ignore (try Unix.kill pid2 Sys.sigterm with _ -> ());
-               (try ignore (Unix.waitpid [] pid2) with _ -> ());
-               List.iter (fun i -> try Unix.kill i Sys.sigterm with _ -> ()) pids;
-               List.iter (fun i -> try ignore (Unix.waitpid [] i) with _ -> ()) pids
-             end
-         in
+         (* Watchdog first: see [kill_children]. *)
+         let live = ref (pid2 :: pids) in
+         let clean () = kill_children live in
          let n = List.length lst0 in
          let rec wait k =
            if k = 0 then
@@ -77,18 +101,14 @@ let partac time lst0 cont =
                  cont (-1) (Proofview.tclZERO Logic_monad.Tac_Timeout)
                end
            else
-             let (pid, status) = Unix.wait () in
-             let interrupted =
-               (* The children have the default SIGINT behaviour, so a
-                  child killed by SIGINT means Ctrl-C: propagate the
-                  interrupt instead of racing with the parent's own
-                  pending [Sys.Break] (losing that race would turn the
-                  user's interrupt into a mere tactic failure). *)
-               match status with
-               | Unix.WSIGNALED s -> s = Sys.sigint
-               | _ -> false
-             in
-             if interrupted then
+             let (pid, status) = restart_on_eintr Unix.wait () in
+             live := List.filter (fun p -> p <> pid) !live;
+             (* The children have the default SIGINT behaviour, so a
+                child killed by SIGINT means Ctrl-C: propagate the
+                interrupt instead of racing with the parent's own
+                pending [Sys.Break] (losing that race would turn the
+                user's interrupt into a mere tactic failure). *)
+             if killed_by_sigint status then
                begin
                  clean ();
                  raise Sys.Break

--- a/src/plugin/timeout.ml
+++ b/src/plugin/timeout.ml
@@ -9,22 +9,29 @@
 
 *)
 
+(* The [Hammer_lib] modules ([Hhpartac] here) must be reached through
+   the pack: only the pack's interface is installed with
+   coq-hammer-tactics, and the dune library is wrapped. *)
+open Hammer_lib
+
 (* ptimeout implements timeout using fork and sleep *)
 let ptimeout n tac =
   let pid = Unix.fork () in
   if pid = 0 then
-    begin (* the worker *)
-      (* See the comment on [Hhpartac.detach_child] (issue #180). *)
-      Hhpartac.detach_child ();
-      Proofview.tclOR
-        (Proofview.tclBIND tac (fun _ -> Unix._exit 0))
-        (fun _ -> Unix._exit 1)
-    end
+    (* the worker; see the comment on [Hhpartac.detach_child] (issue #180) *)
+    Hhpartac.worker n tac
   else
     begin
       let pid2 = Unix.fork () in
       if pid2 = 0 then
-        begin (* the watchdog *)
+        begin (* The watchdog.  Unlike in [Hhpartac.partac], signalling
+                 the worker from here is essentially safe: the parent
+                 blocks in [waitpid] on that single worker, so while
+                 the watchdog lives the worker is unreaped and its pid
+                 cannot be recycled.  (The exception is the instant
+                 between the parent reaping the worker and SIGTERMing
+                 the watchdog, which would have to coincide with the
+                 timeout expiring.) *)
           Hhpartac.detach_child ();
           (try
              Unix.sleep n;

--- a/src/plugin/timeout.ml
+++ b/src/plugin/timeout.ml
@@ -32,38 +32,29 @@ let ptimeout n tac =
            with _ -> ());
           Unix._exit 0
         end;
-      let clean_watchdog () =
-        ignore (try Unix.kill pid2 Sys.sigterm with _ -> ());
-        (try ignore (Unix.waitpid [] pid2) with _ -> ())
-      in
-      let clean_all () =
-        (* Watchdog first: while it lives it may SIGTERM the worker's
-           pid, which must not happen after that pid has been reaped
-           (and possibly recycled). *)
-        clean_watchdog ();
-        ignore (try Unix.kill pid Sys.sigterm with _ -> ());
-        (try ignore (Unix.waitpid [] pid) with _ -> ())
-      in
+      (* Watchdog first: see [Hhpartac.kill_children]. *)
+      let live = ref [pid2; pid] in
       let res =
         try
-          let (_, status) = Unix.waitpid [] pid
-          in
+          let (_, status) = Hhpartac.restart_on_eintr (Unix.waitpid []) pid in
+          live := List.filter (fun p -> p <> pid) !live;
+          Hhpartac.kill_children live;
           match status with
-          | Unix.WEXITED 0 -> clean_watchdog (); `Success
-          | Unix.WSIGNALED s when s = Sys.sigint ->
+          | Unix.WEXITED 0 -> `Success
+          | _ when Hhpartac.killed_by_sigint status ->
              (* The worker has the default SIGINT behaviour, so this
                 means Ctrl-C: the user's interrupt must not be turned
                 into a mere Tac_Timeout failure. *)
-             clean_watchdog (); `Interrupted
-          | _ -> clean_watchdog (); `Timeout
+             `Interrupted
+          | _ -> `Timeout
         with
         | e when CErrors.noncritical e ->
-           clean_all (); `Timeout
+           Hhpartac.kill_children live; `Timeout
         | e ->
            (* Sys.Break in particular: do not swallow the user's
               interrupt; clean up and let it propagate. *)
            let e = Exninfo.capture e in
-           clean_all ();
+           Hhpartac.kill_children live;
            Exninfo.iraise e
       in
       match res with

--- a/src/plugin/timeout.ml
+++ b/src/plugin/timeout.ml
@@ -14,6 +14,8 @@ let ptimeout n tac =
   let pid = Unix.fork () in
   if pid = 0 then
     begin (* the worker *)
+      (* See the comment on [Hhpartac.detach_child] (issue #180). *)
+      Hhpartac.detach_child ();
       Proofview.tclOR
         (Proofview.tclBIND tac (fun _ -> Unix._exit 0))
         (fun _ -> Unix._exit 1)
@@ -23,19 +25,49 @@ let ptimeout n tac =
       let pid2 = Unix.fork () in
       if pid2 = 0 then
         begin (* the watchdog *)
-          Unix.sleep n;
-          Unix.kill pid Sys.sigterm;
+          Hhpartac.detach_child ();
+          (try
+             Unix.sleep n;
+             Unix.kill pid Sys.sigterm
+           with _ -> ());
           Unix._exit 0
         end;
-      let clean () =
-        ignore (try Unix.kill pid2 Sys.sigterm with _ -> ())
+      let clean_watchdog () =
+        ignore (try Unix.kill pid2 Sys.sigterm with _ -> ());
+        (try ignore (Unix.waitpid [] pid2) with _ -> ())
       in
-      try
-        let (_, status) = Unix.waitpid [] pid
-        in
-        match status with
-        | Unix.WEXITED 0 -> clean (); tac
-        | _ -> clean(); Proofview.tclZERO Logic_monad.Tac_Timeout
-      with
-      | _ -> clean (); Proofview.tclZERO Logic_monad.Tac_Timeout
+      let clean_all () =
+        (* Watchdog first: while it lives it may SIGTERM the worker's
+           pid, which must not happen after that pid has been reaped
+           (and possibly recycled). *)
+        clean_watchdog ();
+        ignore (try Unix.kill pid Sys.sigterm with _ -> ());
+        (try ignore (Unix.waitpid [] pid) with _ -> ())
+      in
+      let res =
+        try
+          let (_, status) = Unix.waitpid [] pid
+          in
+          match status with
+          | Unix.WEXITED 0 -> clean_watchdog (); `Success
+          | Unix.WSIGNALED s when s = Sys.sigint ->
+             (* The worker has the default SIGINT behaviour, so this
+                means Ctrl-C: the user's interrupt must not be turned
+                into a mere Tac_Timeout failure. *)
+             clean_watchdog (); `Interrupted
+          | _ -> clean_watchdog (); `Timeout
+        with
+        | e when CErrors.noncritical e ->
+           clean_all (); `Timeout
+        | e ->
+           (* Sys.Break in particular: do not swallow the user's
+              interrupt; clean up and let it propagate. *)
+           let e = Exninfo.capture e in
+           clean_all ();
+           Exninfo.iraise e
+      in
+      match res with
+      | `Success -> tac
+      | `Interrupted -> raise Sys.Break
+      | `Timeout -> Proofview.tclZERO Logic_monad.Tac_Timeout
     end


### PR DESCRIPTION
#180 (which I reported) still reproduces with coq-hammer 1.3.3+9.1 under Proof General:
aborting `best` with C-c C-c can desynchronize the UI from the kernel (e.g.
`Error: nth_ok already exists` for a definition the UI shows as unprocessed).

I had Claude (Fable) locate the root cause and prepare this fix; its analysis is quoted
below. I tested the fix locally with Rocq 9.1 and it seems to work!

---

*The following analysis and fix description were written by Claude (Fable); I'm including
them verbatim.*

**Root cause.** Ctrl-C delivers SIGINT to the terminal's whole foreground process group —
coqtop *and* every child forked by `Hhpartac.partac` (`best`/`hbest`/`sbest`) and
`Timeout.ptimeout` (`hammer` reconstruction, `ptimeout`). coqtop runs with
`Sys.catch_break true`, so each child gets an asynchronous `Sys.Break`. A worker's only
route to `Unix._exit` is

```ocaml
Proofview.tclOR (Proofview.tclBIND tac (fun _ -> Unix._exit 0)) (fun _ -> Unix._exit 1)
```

but `tclOR` only catches *monadic* failures: the engine converts exceptions in tactic
code to monadic failures only when `CErrors.noncritical` holds, and `Sys.Break` is
critical. The interrupt therefore bypasses both `Unix._exit` calls and unwinds the child
into its inherited copy of `Coqloop` — which catches `Sys.Break` by design and resumes
the REPL: the child prints a fresh prompt to the shared stdout and starts reading the
shared stdin, competing with the real coqtop for the IDE protocol with a kernel state
frozen at the fork point. Hence the nondeterministic desync. The watchdogs have no
exception barrier and escape the same way out of `Unix.sleep`; `partac`'s wait loop did
no cleanup when interrupted (leaking children); `ptimeout` caught `Sys.Break` with
`with _ ->`, silently converting the interrupt into `Tac_Timeout` while leaking its
worker. (The ATP forks in `parallel.ml` are immune: their children use a plain OCaml
`try ... with _ -> Unix._exit`, which does catch `Sys.Break` — the monadic wrapper
cannot.) #229's `Unix._exit` change addressed exit-time buffer flushing, which never
happens on this path.

**Fix.** A shared `Hhpartac.detach_child`, run first in every forked child: reset SIGINT
to its default disposition (Ctrl-C simply kills the child), register an `at_exit` guard
`Unix._exit 2` (legitimate terminations use `Unix._exit` and bypass `at_exit`, so a child
that still escapes into the toplevel — e.g. on `Stack_overflow` — reports failure instead
of success, and cannot flush inherited buffers), and redirect fds 0/1/2 to `/dev/null`
(children can never touch the IDE protocol; an escapee reads EOF and terminates).
Watchdog bodies get exception barriers. The parents kill and reap all children before
letting an exception propagate — watchdog first and idempotently, so no signal is ever
sent to a reaped/recycled pid — and when a child was killed by SIGINT they propagate
`Sys.Break` deterministically instead of racing the parent's own pending signal.
`ptimeout` now distinguishes success / interrupt / timeout explicitly and no longer
swallows `Sys.Break` or leaks its worker. Workers communicate only via exit status (the
parent re-runs the winning tactic), so detaching their fds loses nothing.

The same commit applies cleanly to `rocq-9.1` and the `v1.3.3+9.1`/`+9.2` tags, so a
backport PR is easy if wanted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents forked tactic workers and watchdogs from reaching the toplevel on Ctrl-C, fixing IDE/kernel desync (issue #180). Old behavior: children got `Sys.Break`, bypassed `Unix._exit`, and read/wrote the IDE protocol; new behavior: children detach stdio and use default SIGINT, while parents track and reap live pids and propagate interrupts deterministically.

**Changes**
- Add `Hhpartac.detach_child`: reset SIGINT to default, redirect stdin/stdout/stderr to `/dev/null`, install `at_exit` guard; abort with `Unix._exit 2` on failure; avoid closing `devnull` when it equals a std fd.
- Add `Hhpartac.worker` for shared child logic; workers arm a small SIGALRM beyond the timeout to bound orphan lifetime.
- Add `Hhpartac.restart_on_eintr`, `Hhpartac.kill_children` (live-pid tracking; idempotent, re-entrant; watchdog first), and `Hhpartac.killed_by_sigint`.
- `Hhpartac.partac`: watchdog is a pure timer and detaches; parent retries `wait` on EINTR, maintains `live`, propagates `Sys.Break` when any child died to SIGINT, then kills/reaps all children; cleanup runs before raising.
- `Timeout.ptimeout`: `open Hammer_lib`; use `Hhpartac.worker`; watchdog detaches and SIGTERM’s the single worker on expiry; parent retries `waitpid` on EINTR, cleans via `kill_children`; distinguishes success/interrupt/timeout and raises `Sys.Break` on interrupt; no worker leaks.

<sup>Written for commit 4d97ca43ebed6db84977ee689bd742c337f4de29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukaszcz/coqhammer/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

